### PR TITLE
api now returns json data with client data

### DIFF
--- a/spec/Factory/PayPalPaymentMethodNewResourceFactorySpec.php
+++ b/spec/Factory/PayPalPaymentMethodNewResourceFactorySpec.php
@@ -44,7 +44,7 @@ final class PayPalPaymentMethodNewResourceFactorySpec extends ObjectBehavior
         $requestConfiguration->getRequest()->willReturn($request);
 
         $onboardingProcessor->supports($paymentMethod, $request)->willReturn(true);
-        $onboardingProcessor->process($paymentMethod, $request, $httpClient, 'test-url')->willReturn($processedPaymentMethod);
+        $onboardingProcessor->process($paymentMethod, $request)->willReturn($processedPaymentMethod);
 
         $this->create($requestConfiguration, $factory)->shouldReturn($processedPaymentMethod);
     }

--- a/src/Factory/PayPalPaymentMethodNewResourceFactory.php
+++ b/src/Factory/PayPalPaymentMethodNewResourceFactory.php
@@ -49,7 +49,7 @@ final class PayPalPaymentMethodNewResourceFactory implements NewResourceFactoryI
         $request = $requestConfiguration->getRequest();
 
         if ($this->onboardingProcessor->supports($resource, $request)) {
-            return $this->onboardingProcessor->process($resource, $request, $this->httpClient, $this->url);
+            return $this->onboardingProcessor->process($resource, $request);
         }
 
         return $resource;

--- a/src/Onboarding/Processor/BasicOnboardingProcessor.php
+++ b/src/Onboarding/Processor/BasicOnboardingProcessor.php
@@ -27,9 +27,7 @@ final class BasicOnboardingProcessor implements OnboardingProcessorInterface
 
     public function process(
         PaymentMethodInterface $paymentMethod,
-        Request $request,
-        HttpClientInterface $httpClient,
-        string $url
+        Request $request
     ): PaymentMethodInterface {
         if (!$this->supports($paymentMethod, $request)) {
             throw new \DomainException('not supported');
@@ -48,15 +46,6 @@ final class BasicOnboardingProcessor implements OnboardingProcessorInterface
         $response = json_decode($checkPartnerReferralsResponse->getContent(), true);
 
         if (!isset($response['client_id']) || !isset($response['client_secret'])) {
-            $client_data = $httpClient->request('GET',
-                sprintf('%s/partner-referrals/check/%s', $url, (string)$request->query->get('onboarding_id')),
-            );
-        }
-
-        /** @var array $response */
-        $response = json_decode($client_data->getContent(), true);
-
-        if ($response['client_id'] === null) {
             throw new PayPalPluginException();
         }
 

--- a/src/Onboarding/Processor/OnboardingProcessorInterface.php
+++ b/src/Onboarding/Processor/OnboardingProcessorInterface.php
@@ -6,11 +6,10 @@ namespace Sylius\PayPalPlugin\Onboarding\Processor;
 
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 interface OnboardingProcessorInterface
 {
-    public function process(PaymentMethodInterface $paymentMethod, Request $request, HttpClientInterface $httpClient, string $url): PaymentMethodInterface;
+    public function process(PaymentMethodInterface $paymentMethod, Request $request): PaymentMethodInterface;
 
     public function supports(PaymentMethodInterface $paymentMethod, Request $request): bool;
 }


### PR DESCRIPTION
Needs to be merged along with https://github.com/Sylius/PayPalFacilitator/pull/12 

Since we had problems with client_id and client_sercret, now we can ask facilitator about credentials and handle it from different place.  This way we get extra time for paypal to process onboarding. This method is used to authorize client. It could be helpful to collect merchant_id from paypal data;