### PR TITLE
Fix payment complete process

### DIFF
--- a/spec/Processor/PayPalOrderCompleteProcessorSpec.php
+++ b/spec/Processor/PayPalOrderCompleteProcessorSpec.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\PayPalPlugin\Processor;
+
+use Payum\Core\Model\GatewayConfigInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\Model\PaymentMethodInterface;
+use Sylius\PayPalPlugin\Manager\PaymentStateManagerInterface;
+
+final class PayPalOrderCompleteProcessorSpec extends ObjectBehavior
+{
+    function let(PaymentStateManagerInterface $paymentStateManager): void
+    {
+        $this->beConstructedWith($paymentStateManager);
+    }
+
+    function it_completes_pay_pal_order(
+        PaymentStateManagerInterface $paymentStateManager,
+        OrderInterface $order,
+        PaymentInterface $payment,
+        PaymentMethodInterface $paymentMethod,
+        GatewayConfigInterface $gatewayConfig
+    ): void {
+        $order->getLastPayment(PaymentInterface::STATE_PROCESSING)->willReturn($payment);
+
+        $payment->getMethod()->willReturn($paymentMethod);
+        $paymentMethod->getGatewayConfig()->willReturn($gatewayConfig);
+        $gatewayConfig->getGatewayName()->willReturn('paypal');
+
+        $paymentStateManager->complete($payment)->shouldBeCalled();
+
+        $this->completePayPalOrder($order);
+    }
+
+    function it_does_nothing_if_processing_payment_is_not_pay_pal(
+        PaymentStateManagerInterface $paymentStateManager,
+        OrderInterface $order,
+        PaymentInterface $payment,
+        PaymentMethodInterface $paymentMethod,
+        GatewayConfigInterface $gatewayConfig
+    ): void {
+        $order->getLastPayment(PaymentInterface::STATE_PROCESSING)->willReturn($payment);
+
+        $payment->getMethod()->willReturn($paymentMethod);
+        $paymentMethod->getGatewayConfig()->willReturn($gatewayConfig);
+        $gatewayConfig->getGatewayName()->willReturn('stripe');
+
+        $paymentStateManager->complete($payment)->shouldNotBeCalled();
+
+        $this->completePayPalOrder($order);
+    }
+
+    function it_does_nothing_if_there_is_no_processing_payment_for_the_order(
+        PaymentStateManagerInterface $paymentStateManager,
+        OrderInterface $order
+    ): void {
+        $order->getLastPayment(PaymentInterface::STATE_PROCESSING)->willReturn(null);
+
+        $paymentStateManager->complete(Argument::any())->shouldNotBeCalled();
+
+        $this->completePayPalOrder($order);
+    }
+}

--- a/src/Processor/PayPalOrderCompleteProcessor.php
+++ b/src/Processor/PayPalOrderCompleteProcessor.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\PayPalPlugin\Processor;
+
+use Sylius\Bundle\PayumBundle\Model\GatewayConfigInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\Model\PaymentMethodInterface;
+use Sylius\PayPalPlugin\Manager\PaymentStateManagerInterface;
+
+final class PayPalOrderCompleteProcessor
+{
+    /** @var PaymentStateManagerInterface */
+    private $paymentStateManager;
+
+    public function __construct(PaymentStateManagerInterface $paymentStateManager)
+    {
+        $this->paymentStateManager = $paymentStateManager;
+    }
+
+    public function completePayPalOrder(OrderInterface $order): void
+    {
+        $payment = $order->getLastPayment(PaymentInterface::STATE_PROCESSING);
+        if ($payment === null) {
+            return;
+        }
+
+        /** @var PaymentMethodInterface $paymentMethod */
+        $paymentMethod = $payment->getMethod();
+        /** @var GatewayConfigInterface $gatewayConfig */
+        $gatewayConfig = $paymentMethod->getGatewayConfig();
+
+        if ($gatewayConfig->getGatewayName() !== 'paypal') {
+            return;
+        }
+
+        $this->paymentStateManager->complete($payment);
+    }
+}

--- a/src/Resources/config/config.yaml
+++ b/src/Resources/config/config.yaml
@@ -2,7 +2,14 @@ winzou_state_machine:
     sylius_order_checkout:
         callbacks:
             after:
+                complete_pay_pal_order:
+                    on: ['complete']
+                    do: ['@Sylius\PayPalPlugin\Processor\PayPalOrderCompleteProcessor', 'completePayPalOrder']
+                    args: ['object']
+    sylius_payment:
+        callbacks:
+            after:
                 complete_pay_pal_payment:
                     on: ['complete']
-                    do: ['@Sylius\PayPalPlugin\Processor\PayPalPaymentCompleteProcessor', 'completePayPalOrder']
+                    do: ['@Sylius\PayPalPlugin\Processor\PayPalPaymentCompleteProcessor', 'completePayPalPayment']
                     args: ['object']

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -54,9 +54,12 @@
             <argument type="service" id="Sylius\PayPalPlugin\Processor\OrderPaymentProcessor.inner" />
         </service>
 
+        <service id="Sylius\PayPalPlugin\Processor\PayPalOrderCompleteProcessor" public="true">
+            <argument type="service" id="Sylius\PayPalPlugin\Manager\PaymentStateManagerInterface" />
+        </service>
+
         <service id="Sylius\PayPalPlugin\Processor\PayPalPaymentCompleteProcessor" public="true">
             <argument type="service" id="payum" />
-            <argument type="service" id="Sylius\PayPalPlugin\Manager\PaymentStateManagerInterface" />
         </service>
 
         <service


### PR DESCRIPTION
The problem was, `CompleteOrder` payum action was not called after the end of the standard checkout process. Right now, we have two callbacks, so:

* on each order complete, if there is a processing payment (the one that has been already authorized) the payment is completed
* on each payment complete the `CompleteOrder` payum action is called, so completed payment in sylius will **always** be completed in PayPal as well