### PR TITLE
Unify http clients

### DIFF
--- a/src/Resources/config/services/onboarding.xml
+++ b/src/Resources/config/services/onboarding.xml
@@ -15,7 +15,7 @@
             id="Sylius\PayPalPlugin\Onboarding\Processor\OnboardingProcessorInterface"
             class="Sylius\PayPalPlugin\Onboarding\Processor\BasicOnboardingProcessor"
         >
-            <argument type="service" id="http_client" />
+            <argument type="service" id="sylius.http_client" />
             <argument>%sylius.paypal.facilitator_url%</argument>
         </service>
     </services>


### PR DESCRIPTION
There is only one place where we do not use `sylius.http_client` service... And it also results in `The service "Sylius\PayPalPlugin\Factory\PayPalPaymentMethodNewResourceFactory" has a dependency on a non-existent service "http_client".` error on production environment :/ 