### PR TITLE
Generate and pass "invoice_number" to PayPal

### DIFF
--- a/spec/Provider/PaymentReferenceNumberProviderSpec.php
+++ b/spec/Provider/PaymentReferenceNumberProviderSpec.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\PayPalPlugin\Provider;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\PayPalPlugin\Provider\PaymentReferenceNumberProviderInterface;
+
+final class PaymentReferenceNumberProviderSpec extends ObjectBehavior
+{
+    function it_implements_payment_reference_number_provider_interface(): void
+    {
+        $this->shouldImplement(PaymentReferenceNumberProviderInterface::class);
+    }
+
+    function it_provides_reference_number_based_on_payment_id_and_creation_date(PaymentInterface $payment): void
+    {
+        $payment->getId()->willReturn(123);
+        $payment->getCreatedAt()->willReturn(new \DateTime('10-03-2012'));
+
+        $this->provide($payment)->shouldReturn('123-10-03-2012');
+    }
+}

--- a/src/Api/CreateOrderApi.php
+++ b/src/Api/CreateOrderApi.php
@@ -18,6 +18,7 @@ use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\PayPalPlugin\Client\PayPalClientInterface;
+use Sylius\PayPalPlugin\Provider\PaymentReferenceNumberProviderInterface;
 use Webmozart\Assert\Assert;
 
 final class CreateOrderApi implements CreateOrderApiInterface
@@ -25,9 +26,15 @@ final class CreateOrderApi implements CreateOrderApiInterface
     /** @var PayPalClientInterface */
     private $client;
 
-    public function __construct(PayPalClientInterface $client)
-    {
+    /** @var PaymentReferenceNumberProviderInterface */
+    private $paymentReferenceNumberProvider;
+
+    public function __construct(
+        PayPalClientInterface $client,
+        PaymentReferenceNumberProviderInterface $paymentReferenceNumberProvider
+    ) {
         $this->client = $client;
+        $this->paymentReferenceNumberProvider = $paymentReferenceNumberProvider;
     }
 
     public function create(string $token, PaymentInterface $payment, string $referenceId): array
@@ -51,6 +58,7 @@ final class CreateOrderApi implements CreateOrderApiInterface
             'purchase_units' => [
                 [
                     'reference_id' => $referenceId,
+                    'invoice_number' => $this->paymentReferenceNumberProvider->provide($payment),
                     'amount' => [
                         'currency_code' => $order->getCurrencyCode(),
                         'value' => (int) $payment->getAmount() / 100,

--- a/src/Provider/PaymentReferenceNumberProvider.php
+++ b/src/Provider/PaymentReferenceNumberProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PayPalPlugin\Provider;
+
+use Sylius\Component\Core\Model\PaymentInterface;
+
+final class PaymentReferenceNumberProvider implements PaymentReferenceNumberProviderInterface
+{
+    public function provide(PaymentInterface $payment): string
+    {
+        /** @var \DateTime $creationDate */
+        $creationDate = $payment->getCreatedAt();
+
+        return ((string) $payment->getId()) . '-' . $creationDate->format('d-m-Y');
+    }
+}

--- a/src/Provider/PaymentReferenceNumberProviderInterface.php
+++ b/src/Provider/PaymentReferenceNumberProviderInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\PayPalPlugin\Provider;
+
+use Sylius\Component\Core\Model\PaymentInterface;
+
+interface PaymentReferenceNumberProviderInterface
+{
+    public function provide(PaymentInterface $payment): string;
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -180,5 +180,10 @@
             <argument>%sylius.paypal.facilitator_url%</argument>
             <argument type="service" id="sylius.manager.payment_method" />
         </service>
+
+        <service
+            id="Sylius\PayPalPlugin\Provider\PaymentReferenceNumberProviderInterface"
+            class="Sylius\PayPalPlugin\Provider\PaymentReferenceNumberProvider"
+        />
     </services>
 </container>

--- a/src/Resources/config/services/api.xml
+++ b/src/Resources/config/services/api.xml
@@ -50,6 +50,7 @@
             class="Sylius\PayPalPlugin\Api\CreateOrderApi"
         >
             <argument type="service" id="Sylius\PayPalPlugin\Client\PayPalClientInterface" />
+            <argument type="service" id="Sylius\PayPalPlugin\Provider\PaymentReferenceNumberProviderInterface" />
         </service>
 
         <service


### PR DESCRIPTION
As we don't have invoices by default in Sylius, I've decided to generate a reference number based on payment's id and creation date. Should be easy to customize, as there is a separate service responsible for such a functionality.