### PR TITLE
Different taxes problem

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -31,6 +31,7 @@
             <errorLevel type="info">
                 <file name="src/Controller/ProcessPayPalOrderAction.php"/>
                 <file name="src/Payum/Action/CompleteOrderAction.php"/>
+                <file name="src/Controller/UpdatePayPalOrderAction.php"/>
             </errorLevel>
         </MixedArgument>
 
@@ -40,6 +41,7 @@
                 <file name="src/DependencyInjection/SyliusPayPalExtension.php"/>
                 <file name="src/Payum/Action/CompleteOrderAction.php"/>
                 <file name="src/Processor/PayPalPaymentRefundProcessor.php"/>
+                <file name="src/Controller/UpdatePayPalOrderAction.php"/>
             </errorLevel>
         </MixedArrayAccess>
 

--- a/src/Api/CreateOrderApi.php
+++ b/src/Api/CreateOrderApi.php
@@ -100,7 +100,7 @@ final class CreateOrderApi implements CreateOrderApiInterface
                         ],
                     ],
                     'soft_descriptor' => 'Sylius PayPal Payment',
-//                    'items' => $payPalItemData['items'],
+                    'items' => $payPalItemData['items'],
                 ],
             ],
             'application_context' => [

--- a/src/Api/UpdateOrderApi.php
+++ b/src/Api/UpdateOrderApi.php
@@ -47,7 +47,7 @@ final class UpdateOrderApi implements UpdateOrderApiInterface
         PaymentInterface $payment,
         string $referenceId,
         string $merchantId
-    ): void {
+    ): array {
         /** @var OrderInterface $order */
         $order = $payment->getOrder();
         /** @var AddressInterface $address */
@@ -92,7 +92,7 @@ final class UpdateOrderApi implements UpdateOrderApiInterface
             'items' => $payPalItemData['items'],
         ];
 
-        $this->client->patch(
+        return $this->client->patch(
             sprintf('v2/checkout/orders/%s', $orderId),
             $token,
             [
@@ -103,35 +103,5 @@ final class UpdateOrderApi implements UpdateOrderApiInterface
                 ],
             ]
         );
-    }
-
-    public function updatePayPalItemData(
-        string $token,
-        string $orderId,
-        string $referenceId,
-        array $payPalItemData
-    ): void {
-        $value = [
-            'currency_code' => 'USD',
-            'value' => '66.93',
-            'breakdown' => [
-                'shipping' => ['value' => '1.93', 'currency_code' => 'USD'],
-                'item_total' => ['value' => '65.00', 'currency_code' => 'USD'],
-                'tax_total' => ['value' => '0.00', 'currency_code' => 'USD'],
-            ]
-        ];
-
-        $response = $this->client->patch(
-            sprintf('v2/checkout/orders/%s', $orderId),
-            $token,
-            [
-                [
-                    'op' => 'remove',
-                    'path' => sprintf('/purchase_units/@reference_id==\'%s\'/amount', $referenceId),
-                ],
-            ]
-        );
-
-        return;
     }
 }

--- a/src/Api/UpdateOrderApiInterface.php
+++ b/src/Api/UpdateOrderApiInterface.php
@@ -14,12 +14,5 @@ interface UpdateOrderApiInterface
         PaymentInterface $payment,
         string $referenceId,
         string $merchantId
-    ): void;
-
-    public function updatePayPalItemData(
-        string $token,
-        string $orderId,
-        string $referenceId,
-        array $payPalItemData
-    ): void;
+    ): array;
 }

--- a/src/Controller/PayPalButtonsController.php
+++ b/src/Controller/PayPalButtonsController.php
@@ -108,6 +108,7 @@ final class PayPalButtonsController
                 'cancelPayPalPaymentUrl' => $this->router->generate('sylius_paypal_plugin_cancel_payment'),
                 'partnerAttributionId' => $this->payPalConfigurationProvider->getPartnerAttributionId($channel),
                 'locale' => $request->getLocale(),
+                'orderId' => $orderId,
                 'errorPayPalPaymentUrl' => $this->router->generate('sylius_paypal_plugin_payment_error'),
                 'available_countries' => $this->availableCountriesProvider->provide(),
             ]));

--- a/src/Resources/config/services/controller.xml
+++ b/src/Resources/config/services/controller.xml
@@ -103,13 +103,12 @@
         </service>
 
         <service id="Sylius\PayPalPlugin\Controller\UpdatePayPalOrderAction">
-            <argument type="service" id="Sylius\PayPalPlugin\Provider\OrderProviderInterface" />
+            <argument type="service" id="Sylius\PayPalPlugin\Provider\PaymentProviderInterface" />
             <argument type="service" id="Sylius\PayPalPlugin\Api\CacheAuthorizeClientApiInterface" />
             <argument type="service" id="Sylius\PayPalPlugin\Api\OrderDetailsApiInterface" />
             <argument type="service" id="Sylius\PayPalPlugin\Api\UpdateOrderApiInterface" />
             <argument type="service" id="sylius.factory.address" />
             <argument type="service" id="sylius.order_processing.order_processor" />
-            <argument type="service" id="Sylius\PayPalPlugin\Provider\PayPalItemDataProviderInterface" />
         </service>
 
         <service id="Sylius\PayPalPlugin\Controller\CompletePayPalOrderFromPaymentPageAction" public="true">

--- a/src/Resources/config/shop_routing.yaml
+++ b/src/Resources/config/shop_routing.yaml
@@ -35,7 +35,7 @@ sylius_paypal_plugin_process_paypal_order:
         _controller: Sylius\PayPalPlugin\Controller\ProcessPayPalOrderAction
 
 sylius_paypal_plugin_update_paypal_order:
-    path: /update-pay-pal-order/{id}
+    path: /update-pay-pal-order
     methods: [POST]
     defaults:
         _controller: Sylius\PayPalPlugin\Controller\UpdatePayPalOrderAction

--- a/src/Resources/views/payFromCartPage.html.twig
+++ b/src/Resources/views/payFromCartPage.html.twig
@@ -8,7 +8,7 @@
     let cancelPayPalOrderUrl = "{{ path('sylius_paypal_plugin_cancel_order') }}";
     let errorPayPalPaymentUrl = "{{ errorPayPalPaymentUrl }}";
     let availableCountries = {{ available_countries|json_encode|raw }};
-    let updatePayPalOrderUrl = "{{ path('sylius_paypal_plugin_update_paypal_order', {'id': orderId}) }}";
+    let updatePayPalOrderUrl = "{{ path('sylius_paypal_plugin_update_paypal_order') }}";
 
     paypal.Buttons({
         locale: '{{ locale }}',

--- a/src/Resources/views/payFromPaymentPage.html.twig
+++ b/src/Resources/views/payFromPaymentPage.html.twig
@@ -6,6 +6,7 @@
     let cancelPayPalPaymentUrl = "{{ cancelPayPalPaymentUrl }}";
     let errorPayPalPaymentUrl = "{{ errorPayPalPaymentUrl }}";
     let availableCountries = {{ available_countries|json_encode|raw }};
+    let updatePayPalOrderUrl = "{{ path('sylius_paypal_plugin_update_paypal_order') }}";
 
     paypal.Buttons({
         style: {
@@ -46,6 +47,18 @@
             if (!availableCountries.filter(country => country === data.shipping_address.country_code).length) {
                 return actions.reject();
             }
+
+            return fetch(updatePayPalOrderUrl, {
+                method: 'post',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify(data)
+            }).then(res => {
+                if (!res || res.error) {
+                    return actions.reject();
+                }
+
+                return actions.resolve();
+            });
         }
     }).render('#paypal-button-container');
 </script>

--- a/src/Resources/views/payFromProductPage.html.twig
+++ b/src/Resources/views/payFromProductPage.html.twig
@@ -10,6 +10,7 @@
     let cancelPayPalOrderUrl = "{{ path('sylius_paypal_plugin_cancel_order') }}";
     let errorPayPalPaymentUrl = "{{ errorPayPalPaymentUrl }}";
     let availableCountries = {{ available_countries|json_encode|raw }};
+    let updatePayPalOrderUrl = "{{ path('sylius_paypal_plugin_update_paypal_order') }}";
 
     paypal.Buttons({
         locale: '{{ locale }}',
@@ -58,6 +59,18 @@
             if (!availableCountries.filter(country => country === data.shipping_address.country_code).length) {
                 return actions.reject();
             }
+
+            return fetch(updatePayPalOrderUrl, {
+                method: 'post',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify(data)
+            }).then(res => {
+                if (!res || res.error) {
+                    return actions.reject();
+                }
+
+                return actions.resolve();
+            });
         }
     }).render('#paypal-button-container');
 </script>

--- a/src/Resources/views/payWithPaypal.html.twig
+++ b/src/Resources/views/payWithPaypal.html.twig
@@ -88,6 +88,7 @@
         let errorPayPalPaymentUrl = "{{ path('sylius_paypal_plugin_payment_error') }}";
         let availableCountries = {{ available_countries|json_encode|raw }};
         let cancelPayPalPaymentUrl = "{{ path('sylius_paypal_plugin_cancel_checkout_payment') }}";
+        let updatePayPalOrderUrl = "{{ path('sylius_paypal_plugin_update_paypal_order') }}";
 
         paypal.Buttons({
             locale: '{{ locale }}',
@@ -116,6 +117,18 @@
                 if (!availableCountries.filter(country => country === data.shipping_address.country_code).length) {
                     return actions.reject();
                 }
+
+                return fetch(updatePayPalOrderUrl, {
+                    method: 'post',
+                    headers: { 'content-type': 'application/json' },
+                    body: JSON.stringify(data)
+                }).then(res => {
+                    if (!res || res.error) {
+                        return actions.reject();
+                    }
+
+                    return actions.resolve();
+                });
             },
             onCancel: function (data, actions) {
                 return fetch(cancelPayPalPaymentUrl, {


### PR DESCRIPTION
Based on https://github.com/Sylius/PayPalPlugin/pull/102

The proposed solution is calling the Update order API when the shipping address is changed in PayPal checkout (done for now only for PayPal button in the cart).

[This](https://github.com/Sylius/PayPalPlugin/compare/master...Zales0123:different-taxes-problem?expand=1#diff-5cc6cf8f49351ab6670d70aed6844dbeR84) line need to be updated to use a new, full update method introduced in #102. Then it should work like a charm giving us the final resolution of this nasty problem 🖖 