### PR TITLE
Revert "Resolve PayPal URLs and codes automatically"

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,32 @@
     ```bash
     cp -R vendor/sylius/paypal-plugin/src/Resources/views/bundles/* templates/bundles/
     ```
+
+4. Add env variables
+
+    ### Sandbox
+
+    ```
+    #.env
+
+    PAYPAL_API_BASE_URL='https://api.sandbox.paypal.com/'
+    # just for now, it will be eventually hardcoded (as we always want to use Sylius PayPal facilitator)
+    PAYPAL_FACILITATOR_URL='https://paypal.sylius.com'
+    PAYPAL_TRACKING_ID='sylius-ppcp4p-bn-code'
+    ```
+
+    ### Live
+
+    ```
+    #.env
+
+    PAYPAL_API_BASE_URL='https://api.paypal.com/'
+    # just for now, it will be eventually hardcoded (as we always want to use Sylius PayPal facilitator)
+    PAYPAL_FACILITATOR_URL='https://prod.paypal.sylius.com'
+    PAYPAL_TRACKING_ID='sylius-ppcp4p-bn-code'
+    ```
    
-4. Copy and apply migrations
+5. Copy and apply migrations
 
    ```
    cp -R vendor/sylius/paypal-plugin/migrations/ src/Migrations/
@@ -83,7 +107,13 @@ it's required to configure SFTP account and set its data in `.env` file.
 
     ![accounts](docs/reports-accounts.png)
 
-5. Configure username and password in payment method's configuration
+5. Configure following env variables
+
+    ```
+    PAYPAL_REPORTS_SFTP_HOST='reports.paypal.com'
+    PAYPAL_REPORTS_SFTP_USERNAME='USERNAME'
+    PAYPAL_REPORTS_SFTP_PASSWORD='PASSWORD'
+    ```
 
 ## Processing payments
 

--- a/spec/Api/CompleteOrderApiSpec.php
+++ b/spec/Api/CompleteOrderApiSpec.php
@@ -41,7 +41,7 @@ final class CompleteOrderApiSpec extends ObjectBehavior
         $order->getCurrencyCode()->willReturn('PLN');
 
         $client
-            ->post('/v2/checkout/orders/123123/capture', 'TOKEN')
+            ->post('v2/checkout/orders/123123/capture', 'TOKEN')
             ->willReturn(['status' => 'COMPLETED', 'id' => 123])
         ;
 

--- a/spec/Api/CreateOrderApiSpec.php
+++ b/spec/Api/CreateOrderApiSpec.php
@@ -86,7 +86,7 @@ final class CreateOrderApiSpec extends ObjectBehavior
         );
 
         $client->post(
-            '/v2/checkout/orders',
+            'v2/checkout/orders',
             'TOKEN',
             Argument::that(function (array $data): bool {
                 return
@@ -160,7 +160,7 @@ final class CreateOrderApiSpec extends ObjectBehavior
         );
 
         $client->post(
-            '/v2/checkout/orders',
+            'v2/checkout/orders',
             'TOKEN',
             Argument::that(function (array $data): bool {
                 return
@@ -249,7 +249,7 @@ final class CreateOrderApiSpec extends ObjectBehavior
         $paymentReferenceNumberProvider->provide($payment)->willReturn('REFERENCE-NUMBER');
 
         $client->post(
-            '/v2/checkout/orders',
+            'v2/checkout/orders',
             'TOKEN',
             Argument::that(function (array $data): bool {
                 return
@@ -341,7 +341,7 @@ final class CreateOrderApiSpec extends ObjectBehavior
         $paymentReferenceNumberProvider->provide($payment)->willReturn('REFERENCE-NUMBER');
 
         $client->post(
-            '/v2/checkout/orders',
+            'v2/checkout/orders',
             'TOKEN',
             Argument::that(function (array $data): bool {
                 return
@@ -449,7 +449,7 @@ final class CreateOrderApiSpec extends ObjectBehavior
         $paymentReferenceNumberProvider->provide($payment)->willReturn('REFERENCE-NUMBER');
 
         $client->post(
-            '/v2/checkout/orders',
+            'v2/checkout/orders',
             'TOKEN',
             Argument::that(function (array $data): bool {
                 return
@@ -535,7 +535,7 @@ final class CreateOrderApiSpec extends ObjectBehavior
 
         $paymentReferenceNumberProvider->provide($payment)->willReturn('REFERENCE-NUMBER');
         $client->post(
-            '/v2/checkout/orders',
+            'v2/checkout/orders',
             'TOKEN',
             Argument::that(function (array $data): bool {
                 return

--- a/spec/Api/IdentityApiSpec.php
+++ b/spec/Api/IdentityApiSpec.php
@@ -31,7 +31,7 @@ final class IdentityApiSpec extends ObjectBehavior
 
     function it_generates_identity_token(PayPalClientInterface $payPalClient): void
     {
-        $payPalClient->post('/v1/identity/generate-token', 'TOKEN')->willReturn(['client_token' => 'CLIENT-TOKEN']);
+        $payPalClient->post('v1/identity/generate-token', 'TOKEN')->willReturn(['client_token' => 'CLIENT-TOKEN']);
 
         $this->generateToken('TOKEN')->shouldReturn('CLIENT-TOKEN');
     }

--- a/spec/Api/OrderDetailsApiSpec.php
+++ b/spec/Api/OrderDetailsApiSpec.php
@@ -32,7 +32,7 @@ final class OrderDetailsApiSpec extends ObjectBehavior
     function it_provides_details_about_pay_pal_order(PayPalClientInterface $client): void
     {
         $client
-            ->get('/v2/checkout/orders/123123', 'TOKEN')
+            ->get('v2/checkout/orders/123123', 'TOKEN')
             ->willReturn(['total' => 1111])
         ;
 

--- a/spec/Api/RefundPaymentApiSpec.php
+++ b/spec/Api/RefundPaymentApiSpec.php
@@ -33,7 +33,7 @@ final class RefundPaymentApiSpec extends ObjectBehavior
     {
         $client
             ->post(
-                '/v2/payments/captures/123123/refund',
+                'v2/payments/captures/123123/refund',
                 'TOKEN',
                 ['amount' => ['value' => '10.99', 'currency_code' => 'USD'], 'invoice_number' => '123-11-11-2010'],
                 ['PayPal-Auth-Assertion' => 'PAY-PAL-AUTH-ASSERTION']

--- a/spec/Api/UpdateOrderApiSpec.php
+++ b/spec/Api/UpdateOrderApiSpec.php
@@ -68,7 +68,7 @@ final class UpdateOrderApiSpec extends ObjectBehavior
         $order->isShippingRequired()->willReturn(true);
 
         $client->patch(
-            '/v2/checkout/orders/ORDER-ID',
+            'v2/checkout/orders/ORDER-ID',
             'TOKEN',
             Argument::that(function (array $data): bool {
                 return
@@ -119,7 +119,7 @@ final class UpdateOrderApiSpec extends ObjectBehavior
         $order->isShippingRequired()->willReturn(false);
 
         $client->patch(
-            '/v2/checkout/orders/ORDER-ID',
+            'v2/checkout/orders/ORDER-ID',
             'TOKEN',
             Argument::that(function (array $data): bool {
                 return

--- a/spec/Api/WebhookApiSpec.php
+++ b/spec/Api/WebhookApiSpec.php
@@ -18,7 +18,7 @@ final class WebhookApiSpec extends ObjectBehavior
     function it_registers_webhook(PayPalClientInterface $client): void
     {
         $client->post(
-            '/v1/notifications/webhooks',
+            'v1/notifications/webhooks',
             'TOKEN',
             Argument::that(function ($data): bool {
                 return
@@ -33,7 +33,7 @@ final class WebhookApiSpec extends ObjectBehavior
     function it_registers_webhook_without_https(PayPalClientInterface $client): void
     {
         $client->post(
-            '/v1/notifications/webhooks',
+            'v1/notifications/webhooks',
             'TOKEN',
             Argument::that(function ($data): bool {
                 return

--- a/spec/Enabler/PayPalPaymentMethodEnablerSpec.php
+++ b/spec/Enabler/PayPalPaymentMethodEnablerSpec.php
@@ -22,21 +22,17 @@ use Psr\Http\Message\StreamInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\PayPalPlugin\Enabler\PaymentMethodEnablerInterface;
 use Sylius\PayPalPlugin\Exception\PaymentMethodCouldNotBeEnabledException;
-use Sylius\PayPalPlugin\Provider\PayPalConfigurationProviderInterface;
 use Sylius\PayPalPlugin\Registrar\SellerWebhookRegistrarInterface;
 
 final class PayPalPaymentMethodEnablerSpec extends ObjectBehavior
 {
     function let(
         Client $client,
-        PayPalConfigurationProviderInterface $payPalConfigurationProvider,
         ObjectManager $paymentMethodManager,
         SellerWebhookRegistrarInterface $sellerWebhookRegistrar
     ): void {
-        $payPalConfigurationProvider->getFacilitatorUrl()->willReturn('http://base-url.com');
-
         $this->beConstructedWith(
-            $client, $payPalConfigurationProvider, $paymentMethodManager, $sellerWebhookRegistrar
+            $client, 'http://base-url.com', $paymentMethodManager, $sellerWebhookRegistrar
         );
     }
 

--- a/spec/Onboarding/Initiator/OnboardingInitiatorSpec.php
+++ b/spec/Onboarding/Initiator/OnboardingInitiatorSpec.php
@@ -9,20 +9,14 @@ use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\AdminUserInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\PayPalPlugin\Onboarding\Initiator\OnboardingInitiatorInterface;
-use Sylius\PayPalPlugin\Provider\PayPalConfigurationProviderInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Security;
 
 final class OnboardingInitiatorSpec extends ObjectBehavior
 {
-    function let(
-        UrlGeneratorInterface $urlGenerator,
-        Security $security,
-        PayPalConfigurationProviderInterface $payPalConfigurationProvider
-    ): void {
-        $payPalConfigurationProvider->getFacilitatorUrl()->willReturn('https://paypal-url');
-
-        $this->beConstructedWith($urlGenerator, $security, $payPalConfigurationProvider);
+    function let(UrlGeneratorInterface $urlGenerator, Security $security): void
+    {
+        $this->beConstructedWith($urlGenerator, $security, 'https://paypal-url');
     }
 
     function it_implements_onboarding_initiator_interface(): void

--- a/spec/Onboarding/Processor/BasicOnboardingProcessorSpec.php
+++ b/spec/Onboarding/Processor/BasicOnboardingProcessorSpec.php
@@ -13,7 +13,6 @@ use Sylius\Component\Core\Model\PaymentMethod;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\PayPalPlugin\Exception\PayPalPluginException;
 use Sylius\PayPalPlugin\Exception\PayPalWebhookUrlNotValidException;
-use Sylius\PayPalPlugin\Provider\PayPalConfigurationProviderInterface;
 use Sylius\PayPalPlugin\Registrar\SellerWebhookRegistrarInterface;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
@@ -22,12 +21,9 @@ final class BasicOnboardingProcessorSpec extends ObjectBehavior
 {
     function let(
         ClientInterface $httpClient,
-        SellerWebhookRegistrarInterface $sellerWebhookRegistrar,
-        PayPalConfigurationProviderInterface $payPalConfigurationProvider
+        SellerWebhookRegistrarInterface $sellerWebhookRegistrar
     ): void {
-        $payPalConfigurationProvider->getFacilitatorUrl()->willReturn('https://paypal.facilitator.com');
-
-        $this->beConstructedWith($httpClient, $sellerWebhookRegistrar, $payPalConfigurationProvider);
+        $this->beConstructedWith($httpClient, $sellerWebhookRegistrar, 'https://paypal.facilitator.com');
     }
 
     function it_processes_onboarding_for_supported_payment_method_and_request(

--- a/spec/Provider/PayPalConfigurationProviderSpec.php
+++ b/spec/Provider/PayPalConfigurationProviderSpec.php
@@ -15,7 +15,6 @@ namespace spec\Sylius\PayPalPlugin\Provider;
 
 use Payum\Core\Model\GatewayConfigInterface;
 use PhpSpec\ObjectBehavior;
-use Sylius\Component\Channel\Context\ChannelContextInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\Component\Core\Repository\PaymentMethodRepositoryInterface;
@@ -23,14 +22,9 @@ use Sylius\PayPalPlugin\Provider\PayPalConfigurationProviderInterface;
 
 final class PayPalConfigurationProviderSpec extends ObjectBehavior
 {
-    function let(
-        PaymentMethodRepositoryInterface $paymentMethodRepository,
-        ChannelContextInterface $channelContext,
-        ChannelInterface $channel
-    ): void {
-        $channelContext->getChannel()->willReturn($channel);
-
-        $this->beConstructedWith($paymentMethodRepository, $channelContext);
+    function let(PaymentMethodRepositoryInterface $paymentMethodRepository): void
+    {
+        $this->beConstructedWith($paymentMethodRepository);
     }
 
     function it_implements_pay_pal_configuration_provider_interface(): void
@@ -59,76 +53,7 @@ final class PayPalConfigurationProviderSpec extends ObjectBehavior
 
         $payPalGatewayConfig->getConfig()->willReturn(['client_id' => '123123']);
 
-        $this->getClientId()->shouldReturn('123123');
-    }
-
-    function it_returns_api_base_url_from_payment_method_config(
-        PaymentMethodRepositoryInterface $paymentMethodRepository,
-        PaymentMethodInterface $payPalPaymentMethod,
-        GatewayConfigInterface $payPalGatewayConfig,
-        ChannelInterface $channel
-    ): void {
-        $paymentMethodRepository
-            ->findEnabledForChannel($channel)
-            ->willReturn([$payPalPaymentMethod], [$payPalPaymentMethod])
-        ;
-
-        $payPalPaymentMethod->getGatewayConfig()->willReturn($payPalGatewayConfig, $payPalGatewayConfig);
-        $payPalGatewayConfig->getFactoryName()->willReturn('sylius.pay_pal', 'sylius.pay_pal');
-
-        $payPalGatewayConfig
-            ->getConfig()
-            ->willReturn(['sandbox' => true], ['sandbox' => false])
-        ;
-
-        $this->getApiBaseUrl()->shouldReturn('https://api.sandbox.paypal.com');
-        $this->getApiBaseUrl()->shouldReturn('https://api.paypal.com');
-    }
-
-    function it_returns_facilitator_url_from_payment_method_config(
-        PaymentMethodRepositoryInterface $paymentMethodRepository,
-        PaymentMethodInterface $payPalPaymentMethod,
-        GatewayConfigInterface $payPalGatewayConfig,
-        ChannelInterface $channel
-    ): void {
-        $paymentMethodRepository
-            ->findEnabledForChannel($channel)
-            ->willReturn([$payPalPaymentMethod], [$payPalPaymentMethod])
-        ;
-
-        $payPalPaymentMethod->getGatewayConfig()->willReturn($payPalGatewayConfig, $payPalGatewayConfig);
-        $payPalGatewayConfig->getFactoryName()->willReturn('sylius.pay_pal', 'sylius.pay_pal');
-
-        $payPalGatewayConfig
-            ->getConfig()
-            ->willReturn(['sandbox' => true], ['sandbox' => false])
-        ;
-
-        $this->getFacilitatorUrl()->shouldReturn('https://paypal.sylius.com');
-        $this->getFacilitatorUrl()->shouldReturn('https://prod.paypal.sylius.com');
-    }
-
-    function it_returns_reports_sftp_host_from_payment_method_config(
-        PaymentMethodRepositoryInterface $paymentMethodRepository,
-        PaymentMethodInterface $payPalPaymentMethod,
-        GatewayConfigInterface $payPalGatewayConfig,
-        ChannelInterface $channel
-    ): void {
-        $paymentMethodRepository
-            ->findEnabledForChannel($channel)
-            ->willReturn([$payPalPaymentMethod], [$payPalPaymentMethod])
-        ;
-
-        $payPalPaymentMethod->getGatewayConfig()->willReturn($payPalGatewayConfig, $payPalGatewayConfig);
-        $payPalGatewayConfig->getFactoryName()->willReturn('sylius.pay_pal', 'sylius.pay_pal');
-
-        $payPalGatewayConfig
-            ->getConfig()
-            ->willReturn(['sandbox' => true], ['sandbox' => false])
-        ;
-
-        $this->getReportsSftpHost()->shouldReturn('reports.sandbox.paypal.com');
-        $this->getReportsSftpHost()->shouldReturn('reports.paypal.com');
+        $this->getClientId($channel)->shouldReturn('123123');
     }
 
     function it_returns_partner_attribution_id_from_payment_method_config(
@@ -152,7 +77,7 @@ final class PayPalConfigurationProviderSpec extends ObjectBehavior
 
         $payPalGatewayConfig->getConfig()->willReturn(['partner_attribution_id' => '123123']);
 
-        $this->getPartnerAttributionId()->shouldReturn('123123');
+        $this->getPartnerAttributionId($channel)->shouldReturn('123123');
     }
 
     function it_throws_an_exception_if_there_is_no_pay_pal_payment_method_defined(
@@ -167,12 +92,12 @@ final class PayPalConfigurationProviderSpec extends ObjectBehavior
 
         $this
             ->shouldThrow(\InvalidArgumentException::class)
-            ->during('getClientID', [])
+            ->during('getClientID', [$channel])
         ;
 
         $this
             ->shouldThrow(\InvalidArgumentException::class)
-            ->during('getPartnerAttributionId', [])
+            ->during('getPartnerAttributionId', [$channel])
         ;
     }
 
@@ -199,7 +124,7 @@ final class PayPalConfigurationProviderSpec extends ObjectBehavior
 
         $this
             ->shouldThrow(\InvalidArgumentException::class)
-            ->during('getClientID', [])
+            ->during('getClientID', [$channel])
         ;
     }
 
@@ -226,7 +151,7 @@ final class PayPalConfigurationProviderSpec extends ObjectBehavior
 
         $this
             ->shouldThrow(\InvalidArgumentException::class)
-            ->during('getPartnerAttributionId', [])
+            ->during('getPartnerAttributionId', [$channel])
         ;
     }
 }

--- a/src/Api/CompleteOrderApi.php
+++ b/src/Api/CompleteOrderApi.php
@@ -27,6 +27,6 @@ final class CompleteOrderApi implements CompleteOrderApiInterface
 
     public function complete(string $token, string $orderId): array
     {
-        return $this->client->post(sprintf('/v2/checkout/orders/%s/capture', $orderId), $token);
+        return $this->client->post(sprintf('v2/checkout/orders/%s/capture', $orderId), $token);
     }
 }

--- a/src/Api/CreateOrderApi.php
+++ b/src/Api/CreateOrderApi.php
@@ -123,6 +123,6 @@ final class CreateOrderApi implements CreateOrderApiInterface
             $data['application_context']['shipping_preference'] = 'SET_PROVIDED_ADDRESS';
         }
 
-        return $this->client->post('/v2/checkout/orders', $token, $data);
+        return $this->client->post('v2/checkout/orders', $token, $data);
     }
 }

--- a/src/Api/IdentityApi.php
+++ b/src/Api/IdentityApi.php
@@ -27,7 +27,7 @@ final class IdentityApi implements IdentityApiInterface
 
     public function generateToken(string $token): string
     {
-        $content = $this->client->post('/v1/identity/generate-token', $token);
+        $content = $this->client->post('v1/identity/generate-token', $token);
 
         return (string) $content['client_token'];
     }

--- a/src/Api/OrderDetailsApi.php
+++ b/src/Api/OrderDetailsApi.php
@@ -18,6 +18,6 @@ final class OrderDetailsApi implements OrderDetailsApiInterface
 
     public function get(string $token, string $orderId): array
     {
-        return $this->client->get(sprintf('/v2/checkout/orders/%s', $orderId), $token);
+        return $this->client->get(sprintf('v2/checkout/orders/%s', $orderId), $token);
     }
 }

--- a/src/Api/RefundPaymentApi.php
+++ b/src/Api/RefundPaymentApi.php
@@ -34,7 +34,7 @@ final class RefundPaymentApi implements RefundPaymentApiInterface
         string $currencyCode
     ): array {
         return $this->client->post(
-            sprintf('/v2/payments/captures/%s/refund', $paymentId),
+            sprintf('v2/payments/captures/%s/refund', $paymentId),
             $token,
             ['amount' => ['value' => $amount, 'currency_code' => $currencyCode], 'invoice_number' => $invoiceNumber],
             ['PayPal-Auth-Assertion' => $payPalAuthAssertion]

--- a/src/Api/UpdateOrderApi.php
+++ b/src/Api/UpdateOrderApi.php
@@ -96,7 +96,7 @@ final class UpdateOrderApi implements UpdateOrderApiInterface
         }
 
         return $this->client->patch(
-            sprintf('/v2/checkout/orders/%s', $orderId),
+            sprintf('v2/checkout/orders/%s', $orderId),
             $token,
             [
                 [

--- a/src/Api/WebhookApi.php
+++ b/src/Api/WebhookApi.php
@@ -25,6 +25,6 @@ final class WebhookApi implements WebhookApiInterface
             ],
         ];
 
-        return $this->client->post('/v1/notifications/webhooks', $token, $data);
+        return $this->client->post('v1/notifications/webhooks', $token, $data);
     }
 }

--- a/src/Enabler/PayPalPaymentMethodEnabler.php
+++ b/src/Enabler/PayPalPaymentMethodEnabler.php
@@ -18,7 +18,6 @@ use GuzzleHttp\Client;
 use Sylius\Bundle\PayumBundle\Model\GatewayConfigInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\PayPalPlugin\Exception\PaymentMethodCouldNotBeEnabledException;
-use Sylius\PayPalPlugin\Provider\PayPalConfigurationProviderInterface;
 use Sylius\PayPalPlugin\Registrar\SellerWebhookRegistrarInterface;
 
 final class PayPalPaymentMethodEnabler implements PaymentMethodEnablerInterface
@@ -26,8 +25,8 @@ final class PayPalPaymentMethodEnabler implements PaymentMethodEnablerInterface
     /** @var Client */
     private $client;
 
-    /** @var PayPalConfigurationProviderInterface */
-    private $payPalConfigurationProvider;
+    /** @var string */
+    private $baseUrl;
 
     /** @var ObjectManager */
     private $paymentMethodManager;
@@ -37,12 +36,12 @@ final class PayPalPaymentMethodEnabler implements PaymentMethodEnablerInterface
 
     public function __construct(
         Client $client,
-        PayPalConfigurationProviderInterface $payPalConfigurationProvider,
+        string $baseUrl,
         ObjectManager $paymentMethodManager,
         SellerWebhookRegistrarInterface $sellerWebhookRegistrar
     ) {
         $this->client = $client;
-        $this->payPalConfigurationProvider = $payPalConfigurationProvider;
+        $this->baseUrl = $baseUrl;
         $this->paymentMethodManager = $paymentMethodManager;
         $this->sellerWebhookRegistrar = $sellerWebhookRegistrar;
     }
@@ -55,11 +54,7 @@ final class PayPalPaymentMethodEnabler implements PaymentMethodEnablerInterface
 
         $response = $this->client->request(
             'GET',
-            sprintf(
-                '%s/seller-permissions/check/%s',
-                $this->payPalConfigurationProvider->getFacilitatorUrl(),
-                (string) $config['merchant_id']
-            )
+            sprintf('%s/seller-permissions/check/%s', $this->baseUrl, (string) $config['merchant_id'])
         );
 
         $content = (array) json_decode($response->getBody()->getContents(), true);

--- a/src/Form/Type/PayPalConfigurationType.php
+++ b/src/Form/Type/PayPalConfigurationType.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Sylius\PayPalPlugin\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -18,13 +17,12 @@ final class PayPalConfigurationType extends AbstractType
             ->add('client_id', TextType::class, ['label' => 'sylius.pay_pal.client_id', 'attr' => ['readonly' => true]])
             ->add('client_secret', TextType::class, ['label' => 'sylius.pay_pal.client_secret', 'attr' => ['readonly' => true]])
             ->add('merchant_id', HiddenType::class, ['label' => 'sylius.pay_pal.client_secret', 'attr' => ['readonly' => true]])
-            ->add('partner_attribution_id', HiddenType::class, ['label' => 'sylius.pay_pal.partner_attribution_id', 'attr' => ['readonly' => true]])
-            ->add('reports_sftp_password', TextType::class, ['label' => 'sylius.pay_pal.sftp_password', 'required' => false])
-            ->add('reports_sftp_username', TextType::class, ['label' => 'sylius.pay_pal.sftp_username', 'required' => false])
-            ->add('sandbox', CheckboxType::class, ['label' => 'sylius.pay_pal.sandbox'])
             ->add('sylius_merchant_id', HiddenType::class, ['label' => 'sylius.pay_pal.client_secret', 'attr' => ['readonly' => true]])
+            ->add('partner_attribution_id', HiddenType::class, ['label' => 'sylius.pay_pal.partner_attribution_id', 'attr' => ['readonly' => true]])
             // we need to force Sylius Payum integration to postpone creating an order, it's the easiest way
             ->add('use_authorize', HiddenType::class, ['data' => true, 'attr' => ['readonly' => true]])
+            ->add('reports_sftp_username', TextType::class, ['label' => 'sylius.pay_pal.sftp_username', 'required' => false])
+            ->add('reports_sftp_password', TextType::class, ['label' => 'sylius.pay_pal.sftp_password', 'required' => false])
         ;
     }
 }

--- a/src/Onboarding/Initiator/OnboardingInitiator.php
+++ b/src/Onboarding/Initiator/OnboardingInitiator.php
@@ -6,7 +6,6 @@ namespace Sylius\PayPalPlugin\Onboarding\Initiator;
 
 use Sylius\Component\Core\Model\AdminUserInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
-use Sylius\PayPalPlugin\Provider\PayPalConfigurationProviderInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Security;
 
@@ -15,20 +14,17 @@ final class OnboardingInitiator implements OnboardingInitiatorInterface
     /** @var UrlGeneratorInterface */
     private $urlGenerator;
 
+    /** @var string */
+    private $createPartnerReferralsUrl;
+
     /** @var Security */
     private $security;
 
-    /** @var PayPalConfigurationProviderInterface */
-    private $payPalConfigurationProvider;
-
-    public function __construct(
-        UrlGeneratorInterface $urlGenerator,
-        Security $security,
-        PayPalConfigurationProviderInterface $payPalConfigurationProvider
-    ) {
+    public function __construct(UrlGeneratorInterface $urlGenerator, Security $security, string $facilitatorUrl)
+    {
         $this->urlGenerator = $urlGenerator;
         $this->security = $security;
-        $this->payPalConfigurationProvider = $payPalConfigurationProvider;
+        $this->createPartnerReferralsUrl = $facilitatorUrl . '/partner-referrals/create';
     }
 
     public function initiate(PaymentMethodInterface $paymentMethod): string
@@ -41,7 +37,7 @@ final class OnboardingInitiator implements OnboardingInitiatorInterface
         $user = $this->security->getUser();
 
         return append_query_string(
-            $this->payPalConfigurationProvider->getFacilitatorUrl() . '/partner-referrals/create',
+            $this->createPartnerReferralsUrl,
             http_build_query([
                 'email' => $user->getEmail(),
                 'return_url' => $this->urlGenerator->generate('sylius_admin_payment_method_create', [

--- a/src/Onboarding/Processor/BasicOnboardingProcessor.php
+++ b/src/Onboarding/Processor/BasicOnboardingProcessor.php
@@ -9,7 +9,6 @@ use Sylius\Bundle\PayumBundle\Model\GatewayConfig;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\PayPalPlugin\Exception\PayPalPluginException;
 use Sylius\PayPalPlugin\Exception\PayPalWebhookUrlNotValidException;
-use Sylius\PayPalPlugin\Provider\PayPalConfigurationProviderInterface;
 use Sylius\PayPalPlugin\Registrar\SellerWebhookRegistrarInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Webmozart\Assert\Assert;
@@ -22,17 +21,17 @@ final class BasicOnboardingProcessor implements OnboardingProcessorInterface
     /** @var SellerWebhookRegistrarInterface */
     private $sellerWebhookRegistrar;
 
-    /** @var PayPalConfigurationProviderInterface */
-    private $payPalConfigurationProvider;
+    /** @var string */
+    private $url;
 
     public function __construct(
         ClientInterface $httpClient,
         SellerWebhookRegistrarInterface $sellerWebhookRegistrar,
-        PayPalConfigurationProviderInterface $payPalConfigurationProvider
+        string $url
     ) {
         $this->httpClient = $httpClient;
         $this->sellerWebhookRegistrar = $sellerWebhookRegistrar;
-        $this->payPalConfigurationProvider = $payPalConfigurationProvider;
+        $this->url = $url;
     }
 
     public function process(
@@ -51,9 +50,7 @@ final class BasicOnboardingProcessor implements OnboardingProcessorInterface
         $onboardingId = (string) $request->query->get('onboarding_id');
         $checkPartnerReferralsResponse = $this->httpClient->request(
             'GET',
-            sprintf(
-                '%s/partner-referrals/check/%s', $this->payPalConfigurationProvider->getFacilitatorUrl(), $onboardingId
-            ),
+            sprintf('%s/partner-referrals/check/%s', $this->url, $onboardingId),
             [
                 'headers' => [
                     'Content-Type' => 'application/json',

--- a/src/Provider/PayPalConfigurationProvider.php
+++ b/src/Provider/PayPalConfigurationProvider.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sylius\PayPalPlugin\Provider;
 
 use Sylius\Bundle\PayumBundle\Model\GatewayConfigInterface;
-use Sylius\Component\Channel\Context\ChannelContextInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\Component\Core\Repository\PaymentMethodRepositoryInterface;
@@ -25,61 +24,29 @@ final class PayPalConfigurationProvider implements PayPalConfigurationProviderIn
     /** @var PaymentMethodRepositoryInterface */
     private $paymentMethodRepository;
 
-    /** @var ChannelContextInterface */
-    private $channelContext;
-
-    public function __construct(
-        PaymentMethodRepositoryInterface $paymentMethodRepository,
-        ChannelContextInterface $channelContext
-    ) {
+    public function __construct(PaymentMethodRepositoryInterface $paymentMethodRepository)
+    {
         $this->paymentMethodRepository = $paymentMethodRepository;
-        $this->channelContext = $channelContext;
     }
 
-    public function getClientId(): string
+    public function getClientId(ChannelInterface $channel): string
     {
-        $config = $this->getPayPalPaymentMethodConfig();
+        $config = $this->getPayPalPaymentMethodConfig($channel);
         Assert::keyExists($config, 'client_id');
 
         return (string) $config['client_id'];
     }
 
-    public function getPartnerAttributionId(): string
+    public function getPartnerAttributionId(ChannelInterface $channel): string
     {
-        $config = $this->getPayPalPaymentMethodConfig();
+        $config = $this->getPayPalPaymentMethodConfig($channel);
         Assert::keyExists($config, 'partner_attribution_id');
 
         return (string) $config['partner_attribution_id'];
     }
 
-    public function getApiBaseUrl(): string
+    private function getPayPalPaymentMethodConfig(ChannelInterface $channel): array
     {
-        $config = $this->getPayPalPaymentMethodConfig();
-        Assert::keyExists($config, 'sandbox');
-
-        return ((bool) $config['sandbox']) ? 'https://api.sandbox.paypal.com' : 'https://api.paypal.com';
-    }
-
-    public function getFacilitatorUrl(): string
-    {
-        $config = $this->getPayPalPaymentMethodConfig();
-        Assert::keyExists($config, 'sandbox');
-
-        return ((bool) $config['sandbox']) ? 'https://paypal.sylius.com' : 'https://prod.paypal.sylius.com';
-    }
-
-    public function getReportsSftpHost(): string
-    {
-        $config = $this->getPayPalPaymentMethodConfig();
-        Assert::keyExists($config, 'sandbox');
-
-        return ((bool) $config['sandbox']) ? 'reports.sandbox.paypal.com' : 'reports.paypal.com';
-    }
-
-    private function getPayPalPaymentMethodConfig(): array
-    {
-        /** @var ChannelInterface $channel */
-        $channel = $this->channelContext->getChannel();
         $methods = $this->paymentMethodRepository->findEnabledForChannel($channel);
 
         /** @var PaymentMethodInterface $method */

--- a/src/Provider/PayPalConfigurationProviderInterface.php
+++ b/src/Provider/PayPalConfigurationProviderInterface.php
@@ -4,15 +4,11 @@ declare(strict_types=1);
 
 namespace Sylius\PayPalPlugin\Provider;
 
+use Sylius\Component\Core\Model\ChannelInterface;
+
 interface PayPalConfigurationProviderInterface
 {
-    public function getClientId(): string;
+    public function getClientId(ChannelInterface $channel): string;
 
-    public function getPartnerAttributionId(): string;
-
-    public function getApiBaseUrl(): string;
-
-    public function getFacilitatorUrl(): string;
-
-    public function getReportsSftpHost(): string;
+    public function getPartnerAttributionId(ChannelInterface $channel): string;
 }

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -9,6 +9,7 @@
     </imports>
 
     <parameters>
+        <parameter key="sylius.paypal.facilitator_url">%env(resolve:PAYPAL_FACILITATOR_URL)%</parameter>
         <parameter key="sylius.paypal.prioritized_factory_name">sylius.pay_pal</parameter>
     </parameters>
 
@@ -173,7 +174,6 @@
             class="Sylius\PayPalPlugin\Provider\PayPalConfigurationProvider"
         >
             <argument type="service" id="sylius.repository.payment_method" />
-            <argument type="service" id="sylius.context.channel" />
         </service>
 
         <service
@@ -182,7 +182,7 @@
         />
 
         <service id="sylius.paypal.client.sftp" class="phpseclib\Net\SFTP">
-            <argument type="expression">service('Sylius\\PayPalPlugin\\Provider\\PayPalConfigurationProviderInterface').getReportsSftpHost()</argument>
+            <argument>%env(resolve:PAYPAL_REPORTS_SFTP_HOST)%</argument>
         </service>
 
         <service
@@ -217,7 +217,7 @@
             class="Sylius\PayPalPlugin\Enabler\PayPalPaymentMethodEnabler"
         >
             <argument type="service" id="sylius.http_client" />
-            <argument type="service" id="Sylius\PayPalPlugin\Provider\PayPalConfigurationProviderInterface" />
+            <argument>%sylius.paypal.facilitator_url%</argument>
             <argument type="service" id="sylius.manager.payment_method" />
             <argument type="service" id="Sylius\PayPalPlugin\Registrar\SellerWebhookRegistrarInterface" />
         </service>

--- a/src/Resources/config/services/api.xml
+++ b/src/Resources/config/services/api.xml
@@ -13,7 +13,8 @@
             <argument type="service" id="sylius.http_client" />
             <argument type="service" id="monolog.logger.paypal" />
             <argument type="service" id="Sylius\PayPalPlugin\Provider\UuidProviderInterface" />
-            <argument type="service" id="Sylius\PayPalPlugin\Provider\PayPalConfigurationProviderInterface" />
+            <argument>%env(resolve:PAYPAL_API_BASE_URL)%</argument>
+            <argument>%env(resolve:PAYPAL_TRACKING_ID)%</argument>
             <argument>%sylius.pay_pal.request_trials_limit%</argument>
             <argument>%sylius.paypal.logging.increased%</argument>
         </service>

--- a/src/Resources/config/services/controller.xml
+++ b/src/Resources/config/services/controller.xml
@@ -78,6 +78,7 @@
         <service id="Sylius\PayPalPlugin\Controller\PayPalButtonsController">
             <argument type="service" id="twig" />
             <argument type="service" id="router" />
+            <argument type="service" id="sylius.context.channel" />
             <argument type="service" id="Sylius\PayPalPlugin\Provider\PayPalConfigurationProviderInterface" />
             <argument type="service" id="sylius.repository.order" />
             <argument type="service" id="Sylius\PayPalPlugin\Provider\AvailableCountriesProviderInterface" />

--- a/src/Resources/config/services/onboarding.xml
+++ b/src/Resources/config/services/onboarding.xml
@@ -8,7 +8,7 @@
         >
             <argument type="service" id="router" />
             <argument type="service" id="security.helper" />
-            <argument type="service" id="Sylius\PayPalPlugin\Provider\PayPalConfigurationProviderInterface" />
+            <argument>%sylius.paypal.facilitator_url%</argument>
         </service>
 
         <service
@@ -17,7 +17,7 @@
         >
             <argument type="service" id="sylius.http_client" />
             <argument type="service" id="Sylius\PayPalPlugin\Registrar\SellerWebhookRegistrarInterface" />
-            <argument type="service" id="Sylius\PayPalPlugin\Provider\PayPalConfigurationProviderInterface" />
+            <argument>%sylius.paypal.facilitator_url%</argument>
         </service>
     </services>
 </container>

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -12,7 +12,6 @@ sylius:
         label: 'PayPal'
         pay_with_card: 'Pay with Card'
         report: 'Report'
-        sandbox: 'Sandbox'
         sftp_password: 'SFTP Password'
         sftp_username: 'SFTP Username'
         share_data_consent_confirmation: "By clicking Yes, you accept PayPal share data consent"

--- a/tests/Application/.env
+++ b/tests/Application/.env
@@ -21,3 +21,8 @@ DATABASE_URL=mysql://root@127.0.0.1/sylius_pay_pal_plugin_%kernel.environment%?s
 # Delivery is disabled by default via "null://localhost"
 MAILER_URL=smtp://localhost
 ###< symfony/swiftmailer-bundle ###
+
+PAYPAL_TRACKING_ID='sylius-ppcp4p-bn-code'
+PAYPAL_API_BASE_URL='https://api.sandbox.paypal.com/'
+PAYPAL_REPORTS_SFTP_HOST=''
+PAYPAL_FACILITATOR_URL='https://paypal.sylius.com'

--- a/tests/Behat/Context/Setup/PaymentPayPalContext.php
+++ b/tests/Behat/Context/Setup/PaymentPayPalContext.php
@@ -45,6 +45,9 @@ final class PaymentPayPalContext implements Context
     /** @var string */
     private $clientId;
 
+    /** @var string */
+    private $partnerAttributionId;
+
     public function __construct(
         SharedStorageInterface $sharedStorage,
         PaymentMethodRepositoryInterface $paymentMethodRepository,
@@ -52,7 +55,8 @@ final class PaymentPayPalContext implements Context
         array $gatewayFactories,
         TranslatorInterface $translator,
         PayPalSelectPaymentPageInterface $selectPaymentPage,
-        string $clientId
+        string $clientId,
+        string $partnerAttributionId
     ) {
         $this->sharedStorage = $sharedStorage;
         $this->paymentMethodRepository = $paymentMethodRepository;
@@ -61,6 +65,7 @@ final class PaymentPayPalContext implements Context
         $this->translator = $translator;
         $this->selectPaymentPage = $selectPaymentPage;
         $this->clientId = $clientId;
+        $this->partnerAttributionId = $partnerAttributionId;
     }
 
     /**
@@ -104,7 +109,7 @@ final class PaymentPayPalContext implements Context
         $paymentMethod->getGatewayConfig()->setConfig([
             'client_id' => $this->clientId,
             'client_secret' => 'SECRET',
-            'partner_attribution_id' => 'sylius-ppcp4p-bn-code',
+            'partner_attribution_id' => $this->partnerAttributionId,
             'merchant_id' => 'MERCHANT-ID',
             'reports_sftp_username' => 'USERNAME',
             'reports_sftp_password' => 'PASSWORD',

--- a/tests/Behat/Resources/services.xml
+++ b/tests/Behat/Resources/services.xml
@@ -29,6 +29,7 @@
             <argument type="service" id="translator"/>
             <argument type="service" id="Tests\Sylius\PayPalPlugin\Behat\Page\Shop\Checkout\PayPalSelectPaymentPage"/>
             <argument>%env(resolve:TEST_CLIENT_ID)%</argument>
+            <argument>%env(resolve:PAYPAL_TRACKING_ID)%</argument>
         </service>
 
         <service id="Tests\Sylius\PayPalPlugin\Behat\Page\Shop\Checkout\PayPalSelectPaymentPage" parent="sylius.behat.page.shop.checkout.select_payment" public="false"/>


### PR DESCRIPTION
In fact, it was a terrible idea :D A lot of things (especially with facilitator, but not only) can happen before we have even one payment method (1st onboarding case). For now, the simplest solution would be to revert these changes and determine URLs based on plugin configuration 💃 