### PR TITLE
Allow only one seller to be onboarded

### DIFF
--- a/features/trying_to_onboard_more_than_one_pay_pal_seller.feature
+++ b/features/trying_to_onboard_more_than_one_pay_pal_seller.feature
@@ -1,0 +1,15 @@
+@managing_payment_methods
+Feature: Trying to onboard more than one PayPal seller
+    In order to handle PayPal integration properly
+    As an Administrator
+    I want to be prevented from onboarding more than one PayPal seller
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store allows paying with "PayPal" with "PayPal" factory name
+        And I am logged in as an administrator
+
+    @ui
+    Scenario: Trying to onboard second PayPal seller
+        When I try to create a new payment method with "PayPal" gateway factory
+        Then I should be notified that I cannot onboard more than one PayPal seller

--- a/spec/Listener/PayPalPaymentMethodListenerSpec.php
+++ b/spec/Listener/PayPalPaymentMethodListenerSpec.php
@@ -8,22 +8,37 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
+use Sylius\PayPalPlugin\Exception\PayPalPaymentMethodNotFoundException;
 use Sylius\PayPalPlugin\Onboarding\Initiator\OnboardingInitiatorInterface;
+use Sylius\PayPalPlugin\Provider\PayPalPaymentMethodProviderInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 final class PayPalPaymentMethodListenerSpec extends ObjectBehavior
 {
-    function let(OnboardingInitiatorInterface $onboardingInitiator): void
-    {
-        $this->beConstructedWith($onboardingInitiator);
+    function let(
+        OnboardingInitiatorInterface $onboardingInitiator,
+        UrlGeneratorInterface $urlGenerator,
+        FlashBagInterface $flashBag,
+        PayPalPaymentMethodProviderInterface $payPalPaymentMethodProvider
+    ): void {
+        $this->beConstructedWith(
+            $onboardingInitiator,
+            $urlGenerator,
+            $flashBag,
+            $payPalPaymentMethodProvider
+        );
     }
 
     function it_initiates_onboarding_when_creating_a_supported_payment_method(
         OnboardingInitiatorInterface $onboardingInitiator,
+        PayPalPaymentMethodProviderInterface $payPalPaymentMethodProvider,
         ResourceControllerEvent $event,
         PaymentMethodInterface $paymentMethod
     ): void {
         $event->getSubject()->willReturn($paymentMethod);
+        $payPalPaymentMethodProvider->provide()->willThrow(PayPalPaymentMethodNotFoundException::class);
 
         $onboardingInitiator->supports($paymentMethod)->willReturn(true);
 
@@ -34,6 +49,8 @@ final class PayPalPaymentMethodListenerSpec extends ObjectBehavior
         $event->setResponse(Argument::that(static function ($argument): bool {
             return $argument instanceof RedirectResponse && $argument->getTargetUrl() === 'https://example.com/onboarding-url';
         }))->shouldHaveBeenCalled();
+
+        $this->initializeCreate($event);
     }
 
     function it_throws_an_exception_if_subject_is_not_a_payment_method(ResourceControllerEvent $event): void
@@ -43,17 +60,42 @@ final class PayPalPaymentMethodListenerSpec extends ObjectBehavior
         $this->shouldThrow(\InvalidArgumentException::class)->during('initializeCreate', [$event]);
     }
 
-    function it_does_nothing_when_creating_an_unsupported_payment_method(
+    function it_redirects_with_error_if_the_pay_pal_payment_method_already_exists(
+        PayPalPaymentMethodProviderInterface $payPalPaymentMethodProvider,
         OnboardingInitiatorInterface $onboardingInitiator,
+        UrlGeneratorInterface $urlGenerator,
+        FlashBagInterface $flashBag,
         ResourceControllerEvent $event,
         PaymentMethodInterface $paymentMethod
     ): void {
         $event->getSubject()->willReturn($paymentMethod);
+        $payPalPaymentMethodProvider->provide()->willReturn($paymentMethod);
+
+        $flashBag->add('error', 'sylius.pay_pal.more_than_one_seller_not_allowed')->shouldBeCalled();
+
+        $urlGenerator->generate('sylius_admin_payment_method_index')->willReturn('http://redirect-url.com');
+        $event->setResponse(Argument::that(function (RedirectResponse $response): bool {
+            return $response->getTargetUrl() === 'http://redirect-url.com';
+        }))->shouldBeCalled();
+
+        $onboardingInitiator->initiate(Argument::any())->shouldNotBeCalled();
+
+        $this->initializeCreate($event);
+    }
+
+    function it_does_nothing_when_creating_an_unsupported_payment_method(
+        OnboardingInitiatorInterface $onboardingInitiator,
+        PayPalPaymentMethodProviderInterface $payPalPaymentMethodProvider,
+        ResourceControllerEvent $event,
+        PaymentMethodInterface $paymentMethod
+    ): void {
+        $event->getSubject()->willReturn($paymentMethod);
+        $payPalPaymentMethodProvider->provide()->willThrow(PayPalPaymentMethodNotFoundException::class);
 
         $onboardingInitiator->supports($paymentMethod)->willReturn(false);
 
-        $this->initializeCreate($event);
-
         $event->setResponse(Argument::any())->shouldNotHaveBeenCalled();
+
+        $this->initializeCreate($event);
     }
 }

--- a/src/Form/Extension/PaymentMethodTypeExtension.php
+++ b/src/Form/Extension/PaymentMethodTypeExtension.php
@@ -34,7 +34,7 @@ final class PaymentMethodTypeExtension extends AbstractTypeExtension
         });
     }
 
-    public function getExtendedTypes(): iterable
+    public static function getExtendedTypes(): iterable
     {
         return [PaymentMethodType::class];
     }

--- a/src/Listener/PayPalPaymentMethodListener.php
+++ b/src/Listener/PayPalPaymentMethodListener.php
@@ -6,8 +6,12 @@ namespace Sylius\PayPalPlugin\Listener;
 
 use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
+use Sylius\PayPalPlugin\Exception\PayPalPaymentMethodNotFoundException;
 use Sylius\PayPalPlugin\Onboarding\Initiator\OnboardingInitiatorInterface;
+use Sylius\PayPalPlugin\Provider\PayPalPaymentMethodProviderInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Webmozart\Assert\Assert;
 
 final class PayPalPaymentMethodListener
@@ -15,22 +19,56 @@ final class PayPalPaymentMethodListener
     /** @var OnboardingInitiatorInterface */
     private $onboardingInitiator;
 
-    public function __construct(OnboardingInitiatorInterface $onboardingInitiator)
-    {
+    /** @var UrlGeneratorInterface */
+    private $urlGenerator;
+
+    /** @var FlashBagInterface */
+    private $flashBag;
+
+    /** @var PayPalPaymentMethodProviderInterface */
+    private $payPalPaymentMethodProvider;
+
+    public function __construct(
+        OnboardingInitiatorInterface $onboardingInitiator,
+        UrlGeneratorInterface $urlGenerator,
+        FlashBagInterface $flashBag,
+        PayPalPaymentMethodProviderInterface $payPalPaymentMethodProvider
+    ) {
         $this->onboardingInitiator = $onboardingInitiator;
+        $this->urlGenerator = $urlGenerator;
+        $this->flashBag = $flashBag;
+        $this->payPalPaymentMethodProvider = $payPalPaymentMethodProvider;
     }
 
     public function initializeCreate(ResourceControllerEvent $event): void
     {
         $paymentMethod = $event->getSubject();
-
         /** @var PaymentMethodInterface $paymentMethod */
         Assert::isInstanceOf($paymentMethod, PaymentMethodInterface::class);
+
+        if ($this->isTherePayPalPaymentMethod()) {
+            $this->flashBag->add('error', 'sylius.pay_pal.more_than_one_seller_not_allowed');
+
+            $event->setResponse(new RedirectResponse($this->urlGenerator->generate('sylius_admin_payment_method_index')));
+
+            return;
+        }
 
         if (!$this->onboardingInitiator->supports($paymentMethod)) {
             return;
         }
 
         $event->setResponse(new RedirectResponse($this->onboardingInitiator->initiate($paymentMethod)));
+    }
+
+    private function isTherePayPalPaymentMethod(): bool
+    {
+        try {
+            $this->payPalPaymentMethodProvider->provide();
+        } catch (PayPalPaymentMethodNotFoundException $exception) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Provider/PayPalPaymentMethodProvider.php
+++ b/src/Provider/PayPalPaymentMethodProvider.php
@@ -21,15 +21,15 @@ final class PayPalPaymentMethodProvider implements PayPalPaymentMethodProviderIn
 
     public function provide(): PaymentMethodInterface
     {
-        $payments = $this->paymentMethodRepository->findAll();
+        $paymentMethods = $this->paymentMethodRepository->findAll();
 
-        /** @var PaymentMethodInterface $payment */
-        foreach ($payments as $payment) {
+        /** @var PaymentMethodInterface $paymentMethod */
+        foreach ($paymentMethods as $paymentMethod) {
             /** @var GatewayConfigInterface $gatewayConfig */
-            $gatewayConfig = $payment->getGatewayConfig();
+            $gatewayConfig = $paymentMethod->getGatewayConfig();
 
             if ($gatewayConfig->getFactoryName() === 'sylius.pay_pal') {
-                return $payment;
+                return $paymentMethod;
             }
         }
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -28,6 +28,9 @@
 
         <service id="Sylius\PayPalPlugin\Listener\PayPalPaymentMethodListener">
             <argument type="service" id="Sylius\PayPalPlugin\Onboarding\Initiator\OnboardingInitiatorInterface" />
+            <argument type="service" id="router" />
+            <argument type="service" id="session.flash_bag" />
+            <argument type="service" id="Sylius\PayPalPlugin\Provider\PayPalPaymentMethodProviderInterface" />
             <tag name="kernel.event_listener" event="sylius.payment_method.initialize_create" method="initializeCreate" />
         </service>
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -251,5 +251,9 @@
             <argument type="service" id="router" />
             <argument type="service" id="Sylius\PayPalPlugin\Api\WebhookApiInterface" />
         </service>
+
+        <service id="Sylius\PayPalPlugin\Twig\PayPalExtension">
+            <tag name="twig.extension" />
+        </service>
     </services>
 </container>

--- a/src/Resources/translations/flashes.en.yml
+++ b/src/Resources/translations/flashes.en.yml
@@ -6,3 +6,4 @@ sylius:
         payment_not_enabled: 'PayPal payment could not be enabled. Try again later.'
         something_went_wrong: 'Something went wrong. Please, try again.'
         webhook_url_not_valid: 'PayPal could not verify provided webhook url. Make sure it is https and try again'
+        more_than_one_seller_not_allowed: 'You cannot onboard more than one PayPal seller!'

--- a/src/Resources/views/Grid/enablePayPal.html.twig
+++ b/src/Resources/views/Grid/enablePayPal.html.twig
@@ -2,7 +2,9 @@
 
 {% set path = path('sylius_admin_payment_method_create', {'factory': 'sylius.pay_pal'}) %}
 
+{% if not sylius_is_pay_pal_enabled(grid.data.currentPageResults) %}
 <a class="ui labeled buttons icon top floating button yellow" href="{{ path }}" data-confirm-pay-pal-consent>
     <i class="paypal icon"></i>
     {{ 'sylius.pay_pal.enable_paypal'|trans }}
 </a>
+{% endif %}

--- a/src/Twig/PayPalExtension.php
+++ b/src/Twig/PayPalExtension.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\PayPalPlugin\Twig;
+
+use Payum\Core\Model\GatewayConfigInterface;
+use Sylius\Component\Core\Model\PaymentMethodInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class PayPalExtension extends AbstractExtension
+{
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('sylius_is_pay_pal_enabled', [$this, 'isPayPalEnabled']),
+        ];
+    }
+
+    public function isPayPalEnabled(iterable $paymentMethods): bool
+    {
+        /** @var PaymentMethodInterface $paymentMethod */
+        foreach ($paymentMethods as $paymentMethod) {
+            /** @var GatewayConfigInterface $gatewayConfig */
+            $gatewayConfig = $paymentMethod->getGatewayConfig();
+            if ($gatewayConfig->getFactoryName() === 'sylius.pay_pal') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Application/config/services_test.yaml
+++ b/tests/Application/config/services_test.yaml
@@ -1,3 +1,3 @@
 imports:
-    - { resource: "../../Behat/Resources/services.xml" }
     - { resource: "../../../vendor/sylius/sylius/src/Sylius/Behat/Resources/config/services.xml" }
+    - { resource: "../../Behat/Resources/services.xml" }

--- a/tests/Behat/Context/Admin/ManagingPaymentMethodsContext.php
+++ b/tests/Behat/Context/Admin/ManagingPaymentMethodsContext.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace Tests\Sylius\PayPalPlugin\Behat\Context\Admin;
 
 use Behat\Behat\Context\Context;
+use Sylius\Behat\NotificationType;
+use Sylius\Behat\Page\Admin\Crud\IndexPageInterface;
+use Sylius\Behat\Page\Admin\PaymentMethod\CreatePageInterface;
+use Sylius\Behat\Service\NotificationCheckerInterface;
 use Tests\Sylius\PayPalPlugin\Behat\Element\DownloadPayPalReportElementInterface;
 use Webmozart\Assert\Assert;
 
@@ -13,9 +17,20 @@ final class ManagingPaymentMethodsContext implements Context
     /** @var DownloadPayPalReportElementInterface */
     private $downloadPayPalReportElement;
 
-    public function __construct(DownloadPayPalReportElementInterface $downloadPayPalReportElement)
-    {
+    /** @var NotificationCheckerInterface */
+    private $notificationChecker;
+
+    /** @var CreatePageInterface */
+    private $createPage;
+
+    public function __construct(
+        DownloadPayPalReportElementInterface $downloadPayPalReportElement,
+        NotificationCheckerInterface $notificationChecker,
+        CreatePageInterface $createPage
+    ) {
         $this->downloadPayPalReportElement = $downloadPayPalReportElement;
+        $this->notificationChecker = $notificationChecker;
+        $this->createPage = $createPage;
     }
 
     /**
@@ -32,5 +47,24 @@ final class ManagingPaymentMethodsContext implements Context
     public function yesterdayReportCsvFileShouldBeSuccessfullyDownloaded(): void
     {
         Assert::true($this->downloadPayPalReportElement->isCsvReportDownloaded());
+    }
+
+    /**
+     * @When I try to create a new payment method with "PayPal" gateway factory
+     */
+    public function iTryToCreateANewPaymentMethodWithGatewayFactory(): void
+    {
+        $this->createPage->tryToOpen(['factory' => 'sylius.pay_pal']);
+    }
+
+    /**
+     * @Then I should be notified that I cannot onboard more than one PayPal seller
+     */
+    public function iShouldBeNotifiedThatICannotOnboardMoreThanOnePayPalSeller(): void
+    {
+        $this->notificationChecker->checkNotification(
+            'You cannot onboard more than one PayPal seller!',
+            NotificationType::failure()
+        );
     }
 }

--- a/tests/Behat/Resources/services.xml
+++ b/tests/Behat/Resources/services.xml
@@ -19,6 +19,22 @@
 
         <service id="Tests\Sylius\PayPalPlugin\Behat\Context\Admin\ManagingPaymentMethodsContext">
             <argument type="service" id="Tests\Sylius\PayPalPlugin\Behat\Element\DownloadPayPalReportElement" />
+            <argument type="service" id="sylius.behat.notification_checker" />
+            <argument type="service" id="sylius.behat.page.admin.payment_method.create" />
+        </service>
+
+        <service id="sylius.behat.context.ui.admin.managing_payment_methods" class="Sylius\Behat\Context\Ui\Admin\ManagingPaymentMethodsContext">
+            <argument type="service" id="sylius.behat.page.admin.payment_method.create" />
+            <argument type="service" id="sylius.behat.page.admin.payment_method.index" />
+            <argument type="service" id="sylius.behat.page.admin.payment_method.update" />
+            <argument type="service" id="sylius.behat.current_page_resolver" />
+            <argument type="service" id="sylius.behat.notification_checker" />
+            <argument type="collection">
+                <argument key="offline">Offline</argument>
+                <argument key="paypal_express_checkout">Paypal Express Checkout</argument>
+                <argument key="sylius.pay_pal">PayPal</argument>
+                <argument key="stripe_checkout">Stripe Checkout</argument>
+            </argument>
         </service>
 
         <service id="Tests\Sylius\PayPalPlugin\Behat\Context\Setup\PaymentPayPalContext">


### PR DESCRIPTION
Fixes #126 and #115

Even though ultimately we would like to allow one PayPal payment method for each channel, right now multiple PayPal PMs can lead to some unexpected behaviour (as in linked issues). I propose to allow only one seller until the stable release and fix the problems in the later plugin versions 💃 