### PR TITLE
Do not assign PayPal customer to order if the user is logged in

### DIFF
--- a/src/Controller/ProcessPayPalOrderAction.php
+++ b/src/Controller/ProcessPayPalOrderAction.php
@@ -87,8 +87,12 @@ final class ProcessPayPalOrderAction
 
         $data = $this->getOrderDetails($request->request->get('payPalOrderId'), $payment);
 
-        $customer = $this->getOrderCustomer($data['payer']);
-        $order->setCustomer($customer);
+        /** @var CustomerInterface|null $customer */
+        $customer = $order->getCustomer();
+        if ($customer === null) {
+            $customer = $this->getOrderCustomer($data['payer']);
+            $order->setCustomer($customer);
+        }
 
         $purchaseUnit = (array) $data['purchase_units'][0];
         $stateMachine = $this->stateMachineFactory->get($order, OrderCheckoutTransitions::GRAPH);


### PR DESCRIPTION
Fixes #137 

Logged in user is automatically set as an order's customer 💃 