### PR TITLE
Inform about empty billing address after PayPal checkout

### DIFF
--- a/src/Api/CreateOrderApi.php
+++ b/src/Api/CreateOrderApi.php
@@ -88,17 +88,6 @@ final class CreateOrderApi implements CreateOrderApiInterface
                     'payee' => [
                         'merchant_id' => $config['merchant_id'],
                     ],
-                    'shipping' => [
-                        'name' => ['full_name' => 'John Doe'],
-                        'address' => [
-                            'address_line_1' => 'Test St. 123',
-                            'address_line_2' => '6',
-                            'admin_area_1' => 'CA',
-                            'admin_area_2' => 'New York',
-                            'postal_code' => '32000',
-                            'country_code' => 'US',
-                        ],
-                    ],
                     'soft_descriptor' => 'Sylius PayPal Payment',
                     'items' => $payPalItemData['items'],
                 ],
@@ -109,7 +98,7 @@ final class CreateOrderApi implements CreateOrderApiInterface
         ];
 
         $address = $order->getShippingAddress();
-        if ($address !== null) {
+        if ($address !== null && $order->isShippingRequired()) {
             $data['purchase_units'][0]['shipping'] = [
                 'name' => ['full_name' => $address->getFullName()],
                 'address' => [

--- a/src/Controller/ProcessPayPalOrderAction.php
+++ b/src/Controller/ProcessPayPalOrderAction.php
@@ -113,9 +113,12 @@ final class ProcessPayPalOrderAction
         } else {
             $address->setFirstName($customer->getFirstName());
             $address->setLastName($customer->getLastName());
-            $address->setStreet('');
-            $address->setCity('');
-            $address->setPostcode('');
+
+            $defaultAddress = $customer->getDefaultAddress();
+
+            $address->setStreet($defaultAddress ? $defaultAddress->getStreet() : '');
+            $address->setCity($defaultAddress ? $defaultAddress->getCity() : '');
+            $address->setPostcode($defaultAddress ? $defaultAddress->getPostcode() : '');
             $address->setCountryCode($data['payer']['address']['country_code']);
             $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_ADDRESS);
         }

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -260,5 +260,9 @@
         <service id="Sylius\PayPalPlugin\Twig\PayPalExtension">
             <tag name="twig.extension" />
         </service>
+
+        <service id="Sylius\PayPalPlugin\Twig\OrderAddressExtension">
+            <tag name="twig.extension" />
+        </service>
     </services>
 </container>

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -17,3 +17,5 @@ sylius:
         sftp_username: 'SFTP Username'
         share_data_consent_confirmation: "By clicking Yes, you accept PayPal share data consent"
         tender_type: 'Refunded to the PayPal wallet'
+        missing_billing_address_header: 'We could not fetch any billing address from PayPal'
+        missing_billing_address_content: 'Please, go back to the Addressing step and complete it'

--- a/src/Resources/views/bundles/SyliusShopBundle/Common/Order/_addresses.html.twig
+++ b/src/Resources/views/bundles/SyliusShopBundle/Common/Order/_addresses.html.twig
@@ -1,0 +1,23 @@
+<div class="ui segment">
+    <div class="ui {% if order.isShippingRequired() %}two{% else %}one{% endif %} column divided stackable grid">
+        <div class="column" id="sylius-billing-address" {{ sylius_test_html_attribute('billing-address') }}>
+            <div class="ui small dividing header">{{ 'sylius.ui.billing_address'|trans }}</div>
+            {% include '@SyliusShop/Common/_address.html.twig' with {'address': order.billingAddress} %}
+        </div>
+        {% if order.isShippingRequired() %}
+        <div class="column" id="sylius-shipping-address" {{ sylius_test_html_attribute('shipping-address') }}>
+            <div class="ui small dividing header">{{ 'sylius.ui.shipping_address'|trans }}</div>
+            {% include '@SyliusShop/Common/_address.html.twig' with {'address': order.shippingAddress} %}
+        </div>
+        {% endif %}
+    </div>
+</div>
+{% if not order.isShippingRequired() and order.billingAddress.street == '' %}
+<div class="ui icon message">
+    <i class="address card icon"></i>
+    <div class="content">
+        <div class="header">{{ 'sylius.pay_pal.missing_billing_address_header'|trans }}</div>
+        <p>{{ 'sylius.pay_pal.missing_billing_address_content'|trans }}</p>
+    </div>
+</div>
+{% endif %}

--- a/src/Resources/views/bundles/SyliusShopBundle/Common/Order/_addresses.html.twig
+++ b/src/Resources/views/bundles/SyliusShopBundle/Common/Order/_addresses.html.twig
@@ -12,7 +12,7 @@
         {% endif %}
     </div>
 </div>
-{% if not order.isShippingRequired() and order.billingAddress.street == '' %}
+{% if sylius_is_billing_address_missing(order) %}
 <div class="ui icon message">
     <i class="address card icon"></i>
     <div class="content">

--- a/src/Twig/OrderAddressExtension.php
+++ b/src/Twig/OrderAddressExtension.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\PayPalPlugin\Twig;
+
+use Sylius\Component\Core\Model\AddressInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class OrderAddressExtension extends AbstractExtension
+{
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('sylius_is_billing_address_missing', [$this, 'isBillingAddressMissing']),
+        ];
+    }
+
+    public function isBillingAddressMissing(OrderInterface $order): bool
+    {
+        /** @var AddressInterface $billingAddress */
+        $billingAddress = $order->getBillingAddress();
+
+        return
+            !$order->isShippingRequired() &&
+            $billingAddress->getStreet() === '' &&
+            $billingAddress->getPostcode() === '' &&
+            $billingAddress->getCity() === ''
+        ;
+    }
+}


### PR DESCRIPTION
It maybe not fixes #139, but somehow handles the problem. We indeed have no place to get the billing address so it should be passed manually in the addressing step (or should be taken from the default customer address).

<img width="1155" alt="Zrzut ekranu 2020-10-29 o 23 44 22" src="https://user-images.githubusercontent.com/6212718/97640272-af86ac80-1a40-11eb-9b77-78e1dc607e63.png">
