### PR TITLE
[Migration] Adjust namespace to newest Sylius Standard

### DIFF
--- a/etc/travis/sylius18/doctrine_migrations.yaml
+++ b/etc/travis/sylius18/doctrine_migrations.yaml
@@ -3,4 +3,4 @@ doctrine_migrations:
         table_storage:
             table_name: sylius_migrations
     migrations_paths:
-        'Sylius\Migrations': '%kernel.project_dir%/src/Migrations/'
+        'App\Migrations': '%kernel.project_dir%/src/Migrations/'

--- a/migrations/Version20200907102535.php
+++ b/migrations/Version20200907102535.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Migrations;
+namespace App\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;

--- a/tests/Application/config/packages/doctrine_migrations.yaml
+++ b/tests/Application/config/packages/doctrine_migrations.yaml
@@ -2,4 +2,4 @@ doctrine_migrations:
     dir_name: "%kernel.project_dir%/src/Migrations"
 
     # Namespace is arbitrary but should be different from App\Migrations as migrations classes should NOT be autoloaded
-    namespace: Sylius\Migrations
+    namespace: App\Migrations

--- a/tests/Application/src/Migrations/Version20200604080033.php
+++ b/tests/Application/src/Migrations/Version20200604080033.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Migrations;
+namespace App\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;


### PR DESCRIPTION
Despite the note: `Namespace is arbitrary but should be different from App\Migrations as migrations classes should NOT be autoloaded`, the current Sylius Standard configuration suggests `App\Migration` as a namespace(ref. https://github.com/Sylius/Sylius-Standard/blob/master/config/packages/doctrine_migrations.yaml#L6). What is more, this namespace is not an issue anymore: https://github.com/doctrine/DoctrineMigrationsBundle/issues/242.

Without this change, current migration will not work automatically during plugin installation. 