### PR TITLE
Fix service injection of CompletePayPalOrderFromPaymentPageAction

### DIFF
--- a/src/Resources/config/services/controller.xml
+++ b/src/Resources/config/services/controller.xml
@@ -121,7 +121,7 @@
             <argument type="service" id="router" />
             <argument type="service" id="Sylius\PayPalPlugin\Provider\OrderProviderInterface" />
             <argument type="service" id="sm.factory" />
-            <argument type="service" id="fos_oauth_server.entity_manager" />
+            <argument type="service" id="sylius.manager.order" />
         </service>
 
         <service id="Sylius\PayPalPlugin\Controller\PayPalPaymentOnErrorAction">


### PR DESCRIPTION
The `$orderManager` should be injected with `sylius.manager.order`, not `fos_oauth_server.entity_manager`

Fix #191 