### PR TITLE
Conflict with SyliusInvoicingPlugin below 0.16.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
                 node: ["10.x"]
                 mysql: ["5.7", "8.0"]
                 symfony: ["^4.4", "^5.2"]
-                sylius: ["~1.8.0", "~1.9.0", "~1.10@dev"]
+                sylius: ["~1.8.0", "~1.9.0", "~1.10.0"]
 
                 exclude:
                     -
@@ -33,7 +33,7 @@ jobs:
                         symfony: "^5.2"
                     -
                         php: "7.3"
-                        sylius: "~1.10@dev"
+                        sylius: "~1.10.0"
                     -
                         php: "8.0"
                         sylius: "~1.8.0"

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
     },
     "conflict": {
         "symfony/doctrine-bridge": "4.4.16",
-        "doctrine/doctrine-bundle": "2.3.0"
+        "doctrine/doctrine-bundle": "2.3.0",
+        "sylius/invoicing-plugin": "<0.16.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Before [this change](https://github.com/Sylius/InvoicingPlugin/pull/226), it was impossible to place the PayPal order from the Payment page, due to some problems with Invoice generation (missing number on order). Therefore, we should require at least SyliusInvoicingPlugin v0.16.0 and release a new version asap 🖖 🚀 