### PR TITLE
Take care about `sylius_core.prepend_doctrine_migrations` parameters

### DIFF
--- a/src/DependencyInjection/SyliusPayPalExtension.php
+++ b/src/DependencyInjection/SyliusPayPalExtension.php
@@ -43,6 +43,14 @@ final class SyliusPayPalExtension extends Extension implements PrependExtensionI
         if (!$container->hasExtension('doctrine_migrations') || !$container->hasExtension('sylius_labs_doctrine_migrations_extra')) {
             return;
         }
+        
+        
+        if (
+            $container->hasParameter('sylius_core.prepend_doctrine_migrations') &&
+            !$container->getParameter('sylius_core.prepend_doctrine_migrations')
+        ) {
+            return;
+        }
 
         $doctrineConfig = $container->getExtensionConfig('doctrine_migrations');
         $migrationsPath = (array) \array_pop($doctrineConfig)['migrations_paths'];

--- a/src/DependencyInjection/SyliusPayPalExtension.php
+++ b/src/DependencyInjection/SyliusPayPalExtension.php
@@ -43,8 +43,7 @@ final class SyliusPayPalExtension extends Extension implements PrependExtensionI
         if (!$container->hasExtension('doctrine_migrations') || !$container->hasExtension('sylius_labs_doctrine_migrations_extra')) {
             return;
         }
-        
-        
+
         if (
             $container->hasParameter('sylius_core.prepend_doctrine_migrations') &&
             !$container->getParameter('sylius_core.prepend_doctrine_migrations')


### PR DESCRIPTION
Hello,

It seems that the sylius core boolean parameter "sylius_core.prepend_doctrine_migrations" is not used at all in the prepend function and this cause error into environment which used "sqlite" db, for example, and doesn't want to be aborted with Migrations which deals with a DB connector.

Thanks.