### PR TITLE
fix: no extension able to load the configuration

### DIFF
--- a/docs/sandbox-vs-live.md
+++ b/docs/sandbox-vs-live.md
@@ -4,7 +4,7 @@ By default, plugin operates in the sandbox mode. I means all the transactions wo
 To change it, you need to configure the plugin properly:
 
 ```yaml
-sylius_pay_pal_plugin:
+sylius_pay_pal:
     sandbox: false
 ```
 


### PR DESCRIPTION
fix: no extension able to load the configuration for "**sylius_pay_pal_plugin**" instead "**sylius_pay_pal**"

| Q               | A
| --------------- | -----
| Branch?         | 1.4 (bug fixes)
| Bug fix?        | yes
| New feature?    | no
|Related tickets|
![Capture d’écran 2022-06-04 234215](https://user-images.githubusercontent.com/29166550/172023386-a5685f23-bbb7-4a03-b8c5-06652b387732.png)

