### PR TITLE
[Maintenance] Updated composer conflict & config sections, updated GitHub workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,9 @@ jobs:
                 name: Restrict Symfony version
                 if: matrix.symfony != ''
                 run: |
-                    composer global require --no-progress --no-scripts --no-plugins "symfony/flex:^1.10"
+                    composer global config --no-plugins allow-plugins.symfony/flex true
+                    composer global require --no-progress --no-scripts --no-plugins "symfony/flex:1.18.5"
+                    composer config --no-plugins allow-plugins.symfony/thanks true
                     composer config extra.symfony.require "${{ matrix.symfony }}"
 
             -

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
     "conflict": {
         "symfony/doctrine-bridge": "4.4.16",
         "doctrine/doctrine-bundle": "2.3.0",
+        "doctrine/dbal": "^3.0.0",
         "sylius/invoicing-plugin": "<0.16.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,6 @@
     "conflict": {
         "symfony/doctrine-bridge": "4.4.16",
         "doctrine/doctrine-bundle": "2.3.0",
-        "doctrine/orm": "^2.10.0",
         "sylius/invoicing-plugin": "<0.16.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,13 @@
     "autoload-dev": {
         "classmap": ["tests/Application/Kernel.php"]
     },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": false,
+            "ocramius/package-versions":  false,
+            "symfony/flex": true
+        }
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.0-dev"


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.4 (bug fixes, improvements)
| Bug fix?        | no
| New feature?    | no

https://getcomposer.org/doc/06-config.md#allow-plugins
"As of Composer 2.2.0, the allow-plugins option adds a layer of security allowing you to restrict which Composer plugins are able to execute code during a Composer run."

1. Due to the fact above the configuration of composer.json has been updated to process dependencies explicitly
2. Conflict with `doctrine/orm:^2.10.0` has been removed
3. Conflict with `doctrine/dbal:^3.0.0` has been added
4. GitHub workflow has been updated based on https://github.com/Sylius/Sylius/pull/14130/files#diff-dc5f32521b4ae99ff8632eb151f06cb36a62fe139292cbbf3f2a4afc79647581
and
https://github.com/Sylius/Sylius/pull/14106