### PR TITLE
fix window reload on javascript payment callbacks

### DIFF
--- a/src/Resources/views/payWithPaypal.html.twig
+++ b/src/Resources/views/payWithPaypal.html.twig
@@ -268,7 +268,7 @@
                     method: 'post',
                     headers: {},
                     body: error
-                }).then(window.location.reload());
+                }).then(() => window.location.reload());
             },
             onShippingChange: function(data, actions) {
                 if (!availableCountries.filter(country => country === data.shipping_address.country_code).length) {
@@ -292,7 +292,7 @@
                     method: 'post',
                     headers: { 'content-type': 'application/json' },
                     body: JSON.stringify({ payPalOrderId: data.orderID })
-                }).then(window.location.reload());
+                }).then(() => window.location.reload());
             }
         }).render('#paypal-button-container');
 
@@ -319,14 +319,14 @@
                         method: 'post',
                         headers: { 'content-type': 'application/json' },
                         body: JSON.stringify(err)
-                    }).then(window.location.reload());
+                    }).then(() => window.location.reload());
                 },
                 onCancel: function (data, actions) {
                     return fetch(cancelPayPalPaymentUrl, {
                         method: 'post',
                         headers: { 'content-type': 'application/json' },
                         body: JSON.stringify({ payPalOrderId: data.orderID })
-                    }).then(window.location.reload());
+                    }).then(() => window.location.reload());
                 }
             });
 
@@ -451,7 +451,7 @@
                                             method: 'post',
                                             headers: { 'content-type': 'application/json' },
                                             body: JSON.stringify({ payPalOrderId: data.orderID })
-                                        }).then(window.location.reload());
+                                        }).then(() => window.location.reload());
                                     }
 
                                     window.location.href = data.return_url;
@@ -468,7 +468,7 @@
                                     method: 'post',
                                     headers: { 'content-type': 'application/json' },
                                     body: JSON.stringify({ payPalOrderId: processingOrderId })
-                                }).then(window.location.reload());
+                                }).then(() => window.location.reload());
                             });
                         });
                     } else {


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.4
| Bug fix?        | yes
| New feature?    | no
| Related tickets | /

Hi, there was an issue with the javascripts in the payWithPaypal template.

The `window.location.reload()` in error and cancel callbacks was executed instead of being passed as a callback in the `fetch().then()` function.

The page was reloading before the call was made and the payment was never cancelled, so **the payment could not be processed again** !


Had to override locally because half of our paypal orders fell in that and payment were never completed.