### PR TITLE
[Payment] fix cancel payment

### DIFF
--- a/src/Controller/CancelLastPayPalPaymentAction.php
+++ b/src/Controller/CancelLastPayPalPaymentAction.php
@@ -51,6 +51,14 @@ final class CancelLastPayPalPaymentAction
         $paymentStateMachine = $this->stateMachineFactory->get($payment, PaymentTransitions::GRAPH);
         $paymentStateMachine->apply(PaymentTransitions::TRANSITION_CANCEL);
 
+        /** @var PaymentInterface $lastPayment */
+        $lastPayment = $order->getLastPayment();
+        if ($lastPayment->getState() === PaymentInterface::STATE_NEW) {
+            $this->objectManager->flush();
+
+            return new Response('', Response::HTTP_NO_CONTENT);
+        }
+
         $this->orderPaymentProcessor->process($order);
         $this->objectManager->flush();
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.5
| Bug fix?        | yes
| New feature?    | no
| Related tickets | replace #249

If the order already has a payment in the "new" status, then the Sylius orderPaymentProcessor must not be processed, otherwise a new payment in the "cart" status will be created, which will cause errors (2 payments in order ...).

Before : 
![image](https://user-images.githubusercontent.com/6593252/215053880-97319618-b24e-4a10-8281-15b71d494912.png)

After :
![image](https://user-images.githubusercontent.com/6593252/215054517-63061d73-37d3-4644-b16c-f57867a7e7d0.png)
