### PR TITLE
Conflict `behat/mink-selenium2-driver:>=1.7.0` && Bump version of `symfony/flex` to `^2.4`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
                 if: matrix.symfony != ''
                 run: |
                     composer global config --no-plugins allow-plugins.symfony/flex true
-                    composer global require --no-progress --no-scripts --no-plugins "symfony/flex:1.18.5"
+                    composer global require --no-progress --no-scripts --no-plugins "symfony/flex:^2.4"
                     composer config --no-plugins allow-plugins.symfony/thanks true
                     composer config extra.symfony.require "${{ matrix.symfony }}"
 

--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -1,0 +1,10 @@
+# CONFLICTS
+
+This document explains why certain conflicts were added to `composer.json` and
+references related issues.
+
+- `behat/mink-selenium2-driver:>=1.7.0`:
+
+  This version adds strict type to the `Behat\Mink\Driver\Selenium2Driver::visit($url)` method
+  which causes a fatal error because the method signature is no longer compatible with the parent class:
+  `PHP Fatal error:  Declaration of Behat\Mink\Driver\Selenium2Driver::visit(string $url) must be compatible with Behat\Mink\Driver\CoreDriver::visit($url) in /home/runner/work/Sylius-Standard/Sylius-Standard/vendor/behat/mink-selenium2-driver/src/Selenium2Driver.php on line 401`

--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,9 @@
     "autoload-dev": {
         "classmap": ["tests/Application/Kernel.php"]
     },
+    "conflict": {
+        "behat/mink-selenium2-driver": ">=1.7.0"
+    },
     "config": {
         "sort-packages": true,
         "allow-plugins": {


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.5
| Bug fix?        | yes
| New feature?    | no
| Related tickets | https://github.com/Sylius/Sylius-Standard/pull/945

Both changes were interdependent, so I propose to combine them into one PR to achieve the green build