### PR TITLE
Fix and clean up UpdatePayPalOrderAction

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,7 +2,7 @@
 
 1. The following constructor signatures have been changed:
 
-   `Sylius\PayPalPlugin\Controller\UpdatePayPalOrderAction`:
+    `Sylius\PayPalPlugin\Controller\UpdatePayPalOrderAction`:
     ```diff
     public function __construct(
         private readonly PaymentProviderInterface $paymentProvider,
@@ -14,7 +14,7 @@
     )
     ```
 
-   `Sylius\PayPalPlugin\Model\PayPalPurchaseUnit`:
+    `Sylius\PayPalPlugin\Model\PayPalPurchaseUnit`:
     ```diff
     public function __construct(
         private readonly string $referenceId,
@@ -34,7 +34,7 @@
     )
     ```
 
-### UPGRADE FROM 1.5.1 to 1.6
+### UPGRADE FROM 1.5.1 to 1.6.0
 
 1. Support for Sylius 1.13 has been added, it is now the recommended Sylius version to use.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,39 @@
+### UPGRADE FROM 1.6.0 to 1.6.1
+
+1. The following constructor signatures have been changed:
+
+   `Sylius\PayPalPlugin\Controller\UpdatePayPalOrderAction`:
+    ```diff
+    public function __construct(
+        private readonly PaymentProviderInterface $paymentProvider,
+        private readonly CacheAuthorizeClientApiInterface $authorizeClientApi,
+    -   private readonly OrderDetailsApiInterface $orderDetailsApi,
+        private readonly UpdateOrderApiInterface $updateOrderApi,
+        private readonly AddressFactoryInterface $addressFactory,
+        private readonly OrderProcessorInterface $orderProcessor,
+    )
+    ```
+
+   `Sylius\PayPalPlugin\Model\PayPalPurchaseUnit`:
+    ```diff
+    public function __construct(
+        private readonly string $referenceId,
+        private readonly string $invoiceNumber,
+        private readonly string $currencyCode,
+        private readonly int $totalAmount,
+        private readonly int $shippingValue,
+        private readonly float $itemTotalValue,
+        private readonly float $taxTotalValue,
+        private readonly int $discountValue,
+        private readonly string $merchantId,
+        private readonly array $items,
+        private readonly bool $shippingRequired,
+        private readonly ?AddressInterface $shippingAddress = null,
+        private readonly string $softDescriptor = 'Sylius PayPal Payment',
+    +   private readonly int $shippingDiscountValue = 0,
+    )
+    ```
+
 ### UPGRADE FROM 1.5.1 to 1.6
 
 1. Support for Sylius 1.13 has been added, it is now the recommended Sylius version to use.
@@ -69,29 +105,6 @@
             private readonly SellerWebhookRegistrarInterface $sellerWebhookRegistrar,
             private readonly string $url,
    +      private readonly ?RequestFactoryInterface $requestFactory = null,
-    )
-     ```
-
-   `Sylius\PayPalPlugin\Model\PayPalPurchaseUnit`:
-     ```diff
-      use Sylius\Component\Core\Model\AddressInterface;
-      use Webmozart\Assert\Assert;
-
-        public function __construct(
-            private readonly string $referenceId,
-            private readonly string $invoiceNumber,
-            private readonly string $currencyCode,
-            private readonly int $totalAmount,
-            private readonly int $shippingValue,
-            private readonly float $itemTotalValue,
-            private readonly float $taxTotalValue,
-            private readonly int $discountValue,
-            private readonly string $merchantId,
-            private readonly array $items,
-            private readonly bool $shippingRequired,
-            private readonly ?AddressInterface $shippingAddress = null,
-            private readonly string $softDescriptor = 'Sylius PayPal Payment',
-   +      private readonly int $shippingDiscountValue = 0,
     )
      ```
 

--- a/src/Controller/UpdatePayPalOrderAction.php
+++ b/src/Controller/UpdatePayPalOrderAction.php
@@ -28,28 +28,13 @@ use Symfony\Component\HttpFoundation\Response;
 
 final class UpdatePayPalOrderAction
 {
-    private PaymentProviderInterface $paymentProvider;
-
-    private CacheAuthorizeClientApiInterface $authorizeClientApi;
-
-    private UpdateOrderApiInterface $updateOrderApi;
-
-    private AddressFactoryInterface $addressFactory;
-
-    private OrderProcessorInterface $orderProcessor;
-
     public function __construct(
-        PaymentProviderInterface $paymentProvider,
-        CacheAuthorizeClientApiInterface $authorizeClientApi,
-        UpdateOrderApiInterface $updateOrderApi,
-        AddressFactoryInterface $addressFactory,
-        OrderProcessorInterface $orderProcessor,
+        private readonly PaymentProviderInterface $paymentProvider,
+        private readonly CacheAuthorizeClientApiInterface $authorizeClientApi,
+        private readonly UpdateOrderApiInterface $updateOrderApi,
+        private readonly AddressFactoryInterface $addressFactory,
+        private readonly OrderProcessorInterface $orderProcessor,
     ) {
-        $this->paymentProvider = $paymentProvider;
-        $this->authorizeClientApi = $authorizeClientApi;
-        $this->updateOrderApi = $updateOrderApi;
-        $this->addressFactory = $addressFactory;
-        $this->orderProcessor = $orderProcessor;
     }
 
     public function __invoke(Request $request): Response

--- a/src/Controller/UpdatePayPalOrderAction.php
+++ b/src/Controller/UpdatePayPalOrderAction.php
@@ -20,7 +20,6 @@ use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Sylius\PayPalPlugin\Api\CacheAuthorizeClientApiInterface;
-use Sylius\PayPalPlugin\Api\OrderDetailsApiInterface;
 use Sylius\PayPalPlugin\Api\UpdateOrderApiInterface;
 use Sylius\PayPalPlugin\Provider\PaymentProviderInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -33,8 +32,6 @@ final class UpdatePayPalOrderAction
 
     private CacheAuthorizeClientApiInterface $authorizeClientApi;
 
-    private OrderDetailsApiInterface $orderDetailsApi;
-
     private UpdateOrderApiInterface $updateOrderApi;
 
     private AddressFactoryInterface $addressFactory;
@@ -44,14 +41,12 @@ final class UpdatePayPalOrderAction
     public function __construct(
         PaymentProviderInterface $paymentProvider,
         CacheAuthorizeClientApiInterface $authorizeClientApi,
-        OrderDetailsApiInterface $orderDetailsApi,
         UpdateOrderApiInterface $updateOrderApi,
         AddressFactoryInterface $addressFactory,
         OrderProcessorInterface $orderProcessor,
     ) {
         $this->paymentProvider = $paymentProvider;
         $this->authorizeClientApi = $authorizeClientApi;
-        $this->orderDetailsApi = $orderDetailsApi;
         $this->updateOrderApi = $updateOrderApi;
         $this->addressFactory = $addressFactory;
         $this->orderProcessor = $orderProcessor;

--- a/src/Controller/UpdatePayPalOrderAction.php
+++ b/src/Controller/UpdatePayPalOrderAction.php
@@ -47,8 +47,7 @@ final class UpdatePayPalOrderAction
         $paymentMethod = $payment->getMethod();
         $token = $this->authorizeClientApi->authorize($paymentMethod);
 
-        /** @var array $shippingAddress */
-        $shippingAddress = $request->request->get('shipping_address');
+        $shippingAddress = $request->request->all('shipping_address');
 
         /** @var AddressInterface $address */
         $address = $this->addressFactory->createNew();

--- a/src/Resources/config/services/controller.xml
+++ b/src/Resources/config/services/controller.xml
@@ -117,7 +117,6 @@
         <service id="Sylius\PayPalPlugin\Controller\UpdatePayPalOrderAction">
             <argument type="service" id="Sylius\PayPalPlugin\Provider\PaymentProviderInterface" />
             <argument type="service" id="Sylius\PayPalPlugin\Api\CacheAuthorizeClientApiInterface" />
-            <argument type="service" id="Sylius\PayPalPlugin\Api\OrderDetailsApiInterface" />
             <argument type="service" id="Sylius\PayPalPlugin\Api\UpdateOrderApiInterface" />
             <argument type="service" id="sylius.factory.address" />
             <argument type="service" id="sylius.order_processing.order_processor" />


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.6 (bug fixes, improvements)
| Bug fix?        | yes
| New feature?    | no

The UpdatePayPalOrderAction fails to update the PayPal order.

The call of ParameterBag::get('shipping_address') should return a scalar value but returns an array.

