### PR TITLE
Fix ProcessPayPalOrderAction

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -34,6 +34,22 @@
     )
     ```
 
+   `Sylius\PayPalPlugin\Controller\ProcessPayPalOrderAction`:
+   ```diff
+   public function __construct(
+   -   private readonly OrderRepositoryInterface $orderRepository,
+       private readonly CustomerRepositoryInterface $customerRepository,
+       private readonly FactoryInterface $customerFactory,
+       private readonly AddressFactoryInterface $addressFactory,
+       private readonly ObjectManager $orderManager,
+       private readonly StateMachineFactoryInterface|StateMachineInterface $stateMachineFactory,
+       private readonly PaymentStateManagerInterface $paymentStateManager,
+       private readonly CacheAuthorizeClientApiInterface $authorizeClientApi,
+       private readonly OrderDetailsApiInterface $orderDetailsApi,
+       private readonly OrderProviderInterface $orderProvider,
+    )
+     ```
+
 ### UPGRADE FROM 1.5.1 to 1.6.0
 
 1. Support for Sylius 1.13 has been added, it is now the recommended Sylius version to use.

--- a/src/Controller/ProcessPayPalOrderAction.php
+++ b/src/Controller/ProcessPayPalOrderAction.php
@@ -78,7 +78,7 @@ final class ProcessPayPalOrderAction
 
         $purchaseUnit = (array) $data['purchase_units'][0];
 
-        $address = $this->addressFactory->createForCustomer($customer);
+        $address = $this->addressFactory->createNew();
 
         if ($order->isShippingRequired()) {
             $name = explode(' ', $purchaseUnit['shipping']['name']['full_name']);

--- a/src/Controller/ProcessPayPalOrderAction.php
+++ b/src/Controller/ProcessPayPalOrderAction.php
@@ -82,8 +82,8 @@ final class ProcessPayPalOrderAction
 
         if ($order->isShippingRequired()) {
             $name = explode(' ', $purchaseUnit['shipping']['name']['full_name']);
-            $address->setFirstName($name[0]);
-            $address->setLastName($name[1]);
+            $address->setLastName(array_pop($name) ?? '');
+            $address->setFirstName(implode(' ', $name));
             $address->setStreet($purchaseUnit['shipping']['address']['address_line_1']);
             $address->setCity($purchaseUnit['shipping']['address']['admin_area_2']);
             $address->setPostcode($purchaseUnit['shipping']['address']['postal_code']);

--- a/src/Controller/ProcessPayPalOrderAction.php
+++ b/src/Controller/ProcessPayPalOrderAction.php
@@ -23,7 +23,6 @@ use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\Component\Core\OrderCheckoutTransitions;
 use Sylius\Component\Core\Repository\CustomerRepositoryInterface;
-use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 use Sylius\PayPalPlugin\Api\CacheAuthorizeClientApiInterface;
 use Sylius\PayPalPlugin\Api\OrderDetailsApiInterface;
@@ -36,7 +35,6 @@ use Symfony\Component\HttpFoundation\Response;
 final class ProcessPayPalOrderAction
 {
     public function __construct(
-        private readonly OrderRepositoryInterface $orderRepository,
         private readonly CustomerRepositoryInterface $customerRepository,
         private readonly FactoryInterface $customerFactory,
         private readonly AddressFactoryInterface $addressFactory,


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.6 (bug fixes, improvements)
| Bug fix?        | yes
| New feature?    | no

A customer name can contain more than just a first name and last name. It could also contain a salutation, middle names or a title. Using only the first two words of the full_name is therefore not sufficient.

The customer is also added to the address created. This means that the customer can change their shipping address after completing the order and can therefore influence the calculation of shipping costs and tax.
