### PR TITLE
Add German translations for PayPal messages

### DIFF
--- a/src/Resources/translations/flashes.de.yml
+++ b/src/Resources/translations/flashes.de.yml
@@ -1,0 +1,9 @@
+sylius:
+    pay_pal:
+        more_than_one_seller_not_allowed: 'Es ist nicht erlaubt, mehr als einen PayPal-Verkäufer zu registrieren!'
+        order_cancelled: 'Die PayPal-Bestellung wurde storniert.'
+        payment_cancelled: 'Die PayPal-Zahlung wurde storniert.'
+        payment_enabled: 'Die PayPal-Zahlung wurde gerade aktiviert.'
+        payment_not_enabled: 'Die PayPal-Zahlung konnte nicht aktiviert werden. Bitte versuchen Sie es später erneut.'
+        something_went_wrong: 'Es ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.'
+        webhook_url_not_valid: 'PayPal konnte die angegebene Webhook-URL nicht verifizieren. Stellen Sie sicher, dass sie HTTPS nutzt, und versuchen Sie es erneut.'

--- a/src/Resources/translations/messages.de.yml
+++ b/src/Resources/translations/messages.de.yml
@@ -1,0 +1,23 @@
+sylius:
+    pay_pal:
+        back_to_store: 'Zurück zum Geschäft'
+        billing_info: 'Rechnungsadresse entspricht der Bestellung'
+        client_id: 'Client-ID'
+        client_secret: 'Client-Geheimnis'
+        credit_card: 'Kreditkarte'
+        credit_card_number: 'Kreditkartennummer'
+        cvv: 'CVV'
+        different_amount: 'Dies ist der autorisierte Preis. Da Sie die Bestellung nach der Autorisierung geändert haben, zahlen Sie den Betrag, der als Gesamt angezeigt wird.'
+        enable_paypal: 'PayPal aktivieren'
+        expiration_date: 'Ablaufdatum'
+        invalid_form: 'Formular ist ungültig'
+        label: 'PayPal'
+        missing_billing_address_content: 'Bitte gehen Sie zurück zum Adressierungs-Schritt und vervollständigen Sie ihn.'
+        missing_billing_address_header: 'Wir konnten keine Rechnungsadresse von PayPal abrufen.'
+        pay_with_card: 'Mit Karte bezahlen'
+        pay_with_pay_pal: 'Mit PayPal bezahlen'
+        report: 'Bericht'
+        sftp_password: 'SFTP-Passwort'
+        sftp_username: 'SFTP-Benutzername'
+        share_data_consent_confirmation: "Durch Klicken auf Ja akzeptieren Sie die Zustimmung zur Datenfreigabe von PayPal."
+        tender_type: 'Erstattet an das PayPal-Wallet'


### PR DESCRIPTION
This pull request adds German translations for various PayPal-related messages in the Sylius plugin. The translations aim to improve the usability of the PayPal integration for German-speaking users by providing clear and localized messages.

Changes include:

- Added translations for error messages and notifications related to PayPal payments and order processing.

This update enhances the overall user experience for German-speaking customers and maintains consistency with existing localization efforts within the project.
tioned in #Z
