### PR TITLE
[PayPalClient + PayPalClientInterface] Explicit nullable type to remove deprecated log message

### DIFF
--- a/src/Client/PayPalClient.php
+++ b/src/Client/PayPalClient.php
@@ -66,19 +66,19 @@ final class PayPalClient implements PayPalClientInterface
         return $this->request('GET', $url, $token);
     }
 
-    public function post(string $url, string $token, array $data = null, array $extraHeaders = []): array
+    public function post(string $url, string $token, ?array $data = null, array $extraHeaders = []): array
     {
         $headers = array_merge($extraHeaders, ['PayPal-Request-Id' => $this->uuidProvider->provide()]);
 
         return $this->request('POST', $url, $token, $data, $headers);
     }
 
-    public function patch(string $url, string $token, array $data = null): array
+    public function patch(string $url, string $token, ?array $data = null): array
     {
         return $this->request('PATCH', $url, $token, $data);
     }
 
-    private function request(string $method, string $url, string $token, array $data = null, array $extraHeaders = []): array
+    private function request(string $method, string $url, string $token, ?array $data = null, array $extraHeaders = []): array
     {
         /** @var ChannelInterface $channel */
         $channel = $this->channelContext->getChannel();

--- a/src/Client/PayPalClientInterface.php
+++ b/src/Client/PayPalClientInterface.php
@@ -22,7 +22,7 @@ interface PayPalClientInterface
 
     public function get(string $url, string $token): array;
 
-    public function post(string $url, string $token, array $data = null, array $extraHeaders = []): array;
+    public function post(string $url, string $token, ?array $data = null, array $extraHeaders = []): array;
 
-    public function patch(string $url, string $token, array $data = null): array;
+    public function patch(string $url, string $token, ?array $data = null): array;
 }


### PR DESCRIPTION
[PayPalClient + PayPalClientInterface] Fix deprecated message by explicitly defining $data as a nullable array in functions post() patch() and request().

> Deprecated: Sylius\PayPalPlugin\Client\PayPalClientInterface::post(): Implicitly marking parameter $data as nullable is deprecated, the explicit nullable type must be used instead
> 
> Deprecated: Sylius\PayPalPlugin\Client\PayPalClientInterface::patch(): Implicitly marking parameter $data as nullable is deprecated, the explicit nullable type must be used instead
> 
> Deprecated: Sylius\PayPalPlugin\Client\PayPalClient::post(): Implicitly marking parameter $data as nullable is deprecated, the explicit nullable type must be used instead
> 
> Deprecated: Sylius\PayPalPlugin\Client\PayPalClient::patch(): Implicitly marking parameter $data as nullable is deprecated, the explicit nullable type must be used instead
> 
> Deprecated: Sylius\PayPalPlugin\Client\PayPalClient::request(): Implicitly marking parameter $data as nullable is deprecated, the explicit nullable type must be used instead

| Q               | A
| --------------- | -----
| Branch?         | 2.0
| Bug fix?        | no
| New feature?    | no
| Related tickets | none
