### PR TITLE
PaymentAmountVerifier fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,9 @@
             "php-http/discovery": true
         }
     },
+    "conflict": {
+        "symfony/serializer": ">=6.4.23"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.7-dev"

--- a/src/Verifier/PaymentAmountVerifier.php
+++ b/src/Verifier/PaymentAmountVerifier.php
@@ -41,7 +41,7 @@ final class PaymentAmountVerifier implements PaymentAmountVerifierInterface
 
         foreach ($paypalOrderDetails['purchase_units'] as $unit) {
             $stringAmount = $unit['amount']['value'] ?? '0';
-            $totalAmount += (int) ($stringAmount * 100);
+            $totalAmount += (int) round((float) $stringAmount * 100, 0);
         }
 
         return $totalAmount;

--- a/tests/Unit/PaymentAmountVerifierTest.php
+++ b/tests/Unit/PaymentAmountVerifierTest.php
@@ -33,11 +33,11 @@ final class PaymentAmountVerifierTest extends TestCase
         $payment = $this->createMock(PaymentInterface::class);
         $order = $this->createMock(OrderInterface::class);
         $payment->method('getOrder')->willReturn($order);
-        $order->method('getTotal')->willReturn(1500);
+        $order->method('getTotal')->willReturn(4398);
 
         $paypalOrderDetails = [
             'purchase_units' => [
-                ['amount' => ['value' => '10.00']],
+                ['amount' => ['value' => '38.98']],
                 ['amount' => ['value' => '5.00']],
             ],
         ];
@@ -52,11 +52,11 @@ final class PaymentAmountVerifierTest extends TestCase
         $payment = $this->createMock(PaymentInterface::class);
         $order = $this->createMock(OrderInterface::class);
         $payment->method('getOrder')->willReturn($order);
-        $order->method('getTotal')->willReturn(1000);
+        $order->method('getTotal')->willReturn(4500);
 
         $paypalOrderDetails = [
             'purchase_units' => [
-                ['amount' => ['value' => '10.00']],
+                ['amount' => ['value' => '38.98']],
                 ['amount' => ['value' => '5.00']],
             ],
         ];


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | fix
| Bug fix?        | yes
| New feature?    | no

Corrects errors that appeared with some prices.

> E.g. at:['amount' => ['value' => '38.98']],

The same as / duplicated by:
https://github.com/Sylius/PayPalPlugin/pull/364/files