### PR TITLE
Add early returns when processing already created order when returning from PayPal to Sylius

### DIFF
--- a/src/Controller/ProcessPayPalOrderAction.php
+++ b/src/Controller/ProcessPayPalOrderAction.php
@@ -19,6 +19,7 @@ use Sylius\Abstraction\StateMachine\StateMachineInterface;
 use Sylius\Abstraction\StateMachine\WinzouStateMachineAdapter;
 use Sylius\Component\Core\Factory\AddressFactoryInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
+use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\Component\Core\OrderCheckoutTransitions;
@@ -87,8 +88,17 @@ final class ProcessPayPalOrderAction
     {
         $orderId = $request->request->getInt('orderId');
         $order = $this->orderProvider->provideOrderById($orderId);
-        /** @var PaymentInterface $payment */
+
+        if ($order->getState() !== OrderInterface::STATE_NEW) {
+            return new JsonResponse(['orderID' => $orderId]);
+        }
+
+        /** @var PaymentInterface|null $payment */
         $payment = $order->getLastPayment(PaymentInterface::STATE_CART);
+
+        if (null === $payment) {
+            return new JsonResponse(['orderID' => $orderId]);
+        }
 
         $data = $this->getOrderDetails((string) $request->request->get('payPalOrderId'), $payment);
 
@@ -144,13 +154,13 @@ final class ProcessPayPalOrderAction
         } catch (PaymentAmountMismatchException) {
             $this->paymentStateManager->cancel($payment);
 
-            return new JsonResponse(['orderID' => $order->getId()]);
+            return new JsonResponse(['orderID' => $orderId]);
         }
 
         $this->paymentStateManager->create($payment);
         $this->paymentStateManager->process($payment);
 
-        return new JsonResponse(['orderID' => $order->getId()]);
+        return new JsonResponse(['orderID' => $orderId]);
     }
 
     private function getOrderCustomer(array $customerData): CustomerInterface


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7
| Bug fix?        | yes
| New feature?    | no
| Related tickets | 

This PR introduces early return conditions in the checkout flow to handle a specific edge case involving PayPal payments:

When a customer starts a PayPal payment and then returns to Sylius in a different browser tab, they may complete the checkout again, either by going through the entire process or by paying again via PayPal. If they then switch back to the original tab (where the PayPal flow was first initiated) and try to complete the order again, it may result in errors because the order is already completed.

To prevent this, we now short-circuit the flow with early returns if the order has already been placed and there is no payment in the `cart` state, ensuring the customer cannot proceed further in such cases.