### PR TITLE
Prevent unnecessary payment cancellation after PayPal

### DIFF
--- a/src/Controller/CancelLastPayPalPaymentAction.php
+++ b/src/Controller/CancelLastPayPalPaymentAction.php
@@ -54,7 +54,12 @@ final class CancelLastPayPalPaymentAction
         /** @var PaymentInterface $payment */
         $payment = $order->getLastPayment();
 
-        $this->getStateMachine()->apply($payment, PaymentTransitions::GRAPH, PaymentTransitions::TRANSITION_CANCEL);
+        $stateMachine = $this->getStateMachine();
+        if (!$stateMachine->can($payment, PaymentTransitions::GRAPH, PaymentTransitions::TRANSITION_CANCEL)) {
+            return new Response('', Response::HTTP_NO_CONTENT);
+        }
+
+        $stateMachine->apply($payment, PaymentTransitions::GRAPH, PaymentTransitions::TRANSITION_CANCEL);
 
         /** @var PaymentInterface $lastPayment */
         $lastPayment = $order->getLastPayment();

--- a/tests/Unit/Controller/CancelLastPayPalPaymentActionTest.php
+++ b/tests/Unit/Controller/CancelLastPayPalPaymentActionTest.php
@@ -1,0 +1,171 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\PayPalPlugin\Unit\Controller;
+
+use Doctrine\Persistence\ObjectManager;
+use PHPUnit\Framework\TestCase;
+use Sylius\Abstraction\StateMachine\StateMachineInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
+use Sylius\Component\Payment\PaymentTransitions;
+use Sylius\PayPalPlugin\Controller\CancelLastPayPalPaymentAction;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class CancelLastPayPalPaymentActionTest extends TestCase
+{
+    private ObjectManager $objectManager;
+
+    private StateMachineInterface $stateMachine;
+
+    private OrderProcessorInterface $orderProcessor;
+
+    private OrderRepositoryInterface $orderRepository;
+
+    private CancelLastPayPalPaymentAction $action;
+
+    protected function setUp(): void
+    {
+        $this->objectManager = $this->createMock(ObjectManager::class);
+        $this->stateMachine = $this->createMock(StateMachineInterface::class);
+        $this->orderProcessor = $this->createMock(OrderProcessorInterface::class);
+        $this->orderRepository = $this->createMock(OrderRepositoryInterface::class);
+
+        $this->action = new CancelLastPayPalPaymentAction(
+            $this->objectManager,
+            $this->stateMachine,
+            $this->orderProcessor,
+            $this->orderRepository,
+        );
+    }
+
+    public function testReturnNoContentWhenPaymentCannotBeCancelled(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $payment = $this->createMock(PaymentInterface::class);
+        $request = new Request();
+        $request->attributes->set('token', 'order-token');
+
+        $this->orderRepository
+            ->expects($this->once())
+            ->method('findOneByTokenValue')
+            ->with('order-token')
+            ->willReturn($order)
+        ;
+
+        $order->expects($this->once())->method('getLastPayment')->willReturn($payment);
+
+        $this->stateMachine
+            ->expects($this->once())
+            ->method('can')
+            ->with($payment, PaymentTransitions::GRAPH, PaymentTransitions::TRANSITION_CANCEL)
+            ->willReturn(false)
+        ;
+
+        $this->stateMachine->expects($this->never())->method('apply');
+        $this->objectManager->expects($this->never())->method('flush');
+
+        $response = ($this->action)($request);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertEquals('', $response->getContent());
+    }
+
+    public function testCancelPaymentWhenTransitionIsPossible(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $payment = $this->createMock(PaymentInterface::class);
+        $lastPayment = $this->createMock(PaymentInterface::class);
+        $request = new Request();
+        $request->attributes->set('token', 'order-token');
+
+        $this->orderRepository
+            ->expects($this->once())
+            ->method('findOneByTokenValue')
+            ->with('order-token')
+            ->willReturn($order)
+        ;
+
+        $order->expects($this->exactly(2))->method('getLastPayment')->willReturn($payment, $lastPayment);
+
+        $this->stateMachine
+            ->expects($this->once())
+            ->method('can')
+            ->with($payment, PaymentTransitions::GRAPH, PaymentTransitions::TRANSITION_CANCEL)
+            ->willReturn(true)
+        ;
+
+        $this->stateMachine
+            ->expects($this->once())
+            ->method('apply')
+            ->with($payment, PaymentTransitions::GRAPH, PaymentTransitions::TRANSITION_CANCEL)
+        ;
+
+        $lastPayment->expects($this->once())->method('getState')->willReturn(PaymentInterface::STATE_CART);
+
+        $this->orderProcessor->expects($this->once())->method('process')->with($order);
+        $this->objectManager->expects($this->once())->method('flush');
+
+        $response = ($this->action)($request);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertEquals('', $response->getContent());
+    }
+
+    public function testSkipOrderProcessingWhenLastPaymentIsNew(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $payment = $this->createMock(PaymentInterface::class);
+        $lastPayment = $this->createMock(PaymentInterface::class);
+        $request = new Request();
+        $request->attributes->set('token', 'order-token');
+
+        $this->orderRepository
+            ->expects($this->once())
+            ->method('findOneByTokenValue')
+            ->with('order-token')
+            ->willReturn($order)
+        ;
+
+        $order->expects($this->exactly(2))->method('getLastPayment')->willReturn($payment, $lastPayment);
+
+        $this->stateMachine
+            ->expects($this->once())
+            ->method('can')
+            ->with($payment, PaymentTransitions::GRAPH, PaymentTransitions::TRANSITION_CANCEL)
+            ->willReturn(true)
+        ;
+
+        $this->stateMachine
+            ->expects($this->once())
+            ->method('apply')
+            ->with($payment, PaymentTransitions::GRAPH, PaymentTransitions::TRANSITION_CANCEL)
+        ;
+
+        $lastPayment->expects($this->once())->method('getState')->willReturn(PaymentInterface::STATE_NEW);
+
+        $this->orderProcessor->expects($this->never())->method('process');
+        $this->objectManager->expects($this->once())->method('flush');
+
+        $response = ($this->action)($request);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertEquals('', $response->getContent());
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7
| Bug fix?        | yes
| New feature?    | no
| Related tickets | 

Currently, after completing checkout and being redirected to PayPal, regardless of whether the payment is completed or canceled by the user, Sylius always attempts to cancel the payment upon return. This leads to state machine errors when the payment has already been completed, the system still tries to cancel it, which is incorrect and may cause unexpected behavior.

This PR updates the logic to ensure that the payment is only canceled when it should be and when it is still possible.