### PR TITLE
Resolves a problems during the order process.

### DIFF
--- a/src/Controller/CancelLastPayPalPaymentAction.php
+++ b/src/Controller/CancelLastPayPalPaymentAction.php
@@ -54,7 +54,12 @@ final class CancelLastPayPalPaymentAction
         /** @var PaymentInterface $payment */
         $payment = $order->getLastPayment();
 
-        $this->getStateMachine()->apply($payment, PaymentTransitions::GRAPH, PaymentTransitions::TRANSITION_CANCEL);
+        $stateMachine = $this->getStateMachine();
+        if (!$stateMachine->can($payment, PaymentTransitions::GRAPH, PaymentTransitions::TRANSITION_CANCEL)) {
+            return new Response('', Response::HTTP_NO_CONTENT);
+        }
+
+        $stateMachine->apply($payment, PaymentTransitions::GRAPH, PaymentTransitions::TRANSITION_CANCEL);
 
         /** @var PaymentInterface $lastPayment */
         $lastPayment = $order->getLastPayment();

--- a/src/Controller/ProcessPayPalOrderAction.php
+++ b/src/Controller/ProcessPayPalOrderAction.php
@@ -89,10 +89,6 @@ final class ProcessPayPalOrderAction
         $orderId = $request->request->getInt('orderId');
         $order = $this->orderProvider->provideOrderById($orderId);
 
-        if ($order->getState() !== OrderInterface::STATE_NEW) {
-            return new JsonResponse(['orderID' => $orderId]);
-        }
-
         /** @var PaymentInterface|null $payment */
         $payment = $order->getLastPayment(PaymentInterface::STATE_CART);
 
@@ -156,9 +152,6 @@ final class ProcessPayPalOrderAction
 
             return new JsonResponse(['orderID' => $orderId]);
         }
-
-        $this->paymentStateManager->create($payment);
-        $this->paymentStateManager->process($payment);
 
         return new JsonResponse(['orderID' => $orderId]);
     }

--- a/src/Form/Type/PayPalConfigurationType.php
+++ b/src/Form/Type/PayPalConfigurationType.php
@@ -17,21 +17,54 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 
 final class PayPalConfigurationType extends AbstractType
 {
+    private const HIDDEN_FIELDS = [
+        'merchant_id',
+        'sylius_merchant_id',
+        'partner_attribution_id',
+        'use_authorize',
+    ];
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        $originalData = [];
+
         $builder
-            ->add('client_id', TextType::class, ['label' => 'sylius.pay_pal.client_id', 'attr' => ['readonly' => true]])
-            ->add('client_secret', TextType::class, ['label' => 'sylius.pay_pal.client_secret', 'attr' => ['readonly' => true]])
-            ->add('merchant_id', HiddenType::class, ['label' => 'sylius.pay_pal.client_secret', 'attr' => ['readonly' => true]])
-            ->add('sylius_merchant_id', HiddenType::class, ['label' => 'sylius.pay_pal.client_secret', 'attr' => ['readonly' => true]])
-            ->add('partner_attribution_id', HiddenType::class, ['label' => 'sylius.pay_pal.partner_attribution_id', 'attr' => ['readonly' => true]])
+            ->add('client_id', TextType::class, ['label' => 'sylius_paypal.client_id', 'attr' => ['readonly' => true]])
+            ->add('client_secret', TextType::class, ['label' => 'sylius_paypal.client_secret', 'attr' => ['readonly' => true]])
+            ->add('merchant_id', HiddenType::class, ['label' => 'sylius_paypal.client_secret', 'attr' => ['readonly' => true]])
+            ->add('sylius_merchant_id', HiddenType::class, ['label' => 'sylius_paypal.client_secret', 'attr' => ['readonly' => true]])
+            ->add('partner_attribution_id', HiddenType::class, ['label' => 'sylius_paypal.partner_attribution_id', 'attr' => ['readonly' => true]])
             // we need to force Sylius Payum integration to postpone creating an order, it's the easiest way
             ->add('use_authorize', HiddenType::class, ['data' => true, 'attr' => ['readonly' => true]])
-            ->add('reports_sftp_username', TextType::class, ['label' => 'sylius.pay_pal.sftp_username', 'required' => false])
-            ->add('reports_sftp_password', TextType::class, ['label' => 'sylius.pay_pal.sftp_password', 'required' => false])
+            ->add('reports_sftp_username', TextType::class, ['label' => 'sylius_paypal.sftp_username', 'required' => false])
+            ->add('reports_sftp_password', TextType::class, ['label' => 'sylius_paypal.sftp_password', 'required' => false])
         ;
+
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use (&$originalData): void {
+            $data = $event->getData();
+            if (is_array($data)) {
+                $originalData = $data;
+            }
+        });
+
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) use (&$originalData): void {
+            $submitted = $event->getData() ?? [];
+
+            foreach (self::HIDDEN_FIELDS as $field) {
+                if (
+                    !array_key_exists($field, $submitted) &&
+                    array_key_exists($field, $originalData)
+                ) {
+                    $submitted[$field] = $originalData[$field];
+                }
+            }
+
+            $event->setData($submitted);
+        });
     }
 }

--- a/tests/Unit/Controller/CancelLastPayPalPaymentActionTest.php
+++ b/tests/Unit/Controller/CancelLastPayPalPaymentActionTest.php
@@ -1,0 +1,171 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\PayPalPlugin\Unit\Controller;
+
+use Doctrine\Persistence\ObjectManager;
+use PHPUnit\Framework\TestCase;
+use Sylius\Abstraction\StateMachine\StateMachineInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
+use Sylius\Component\Payment\PaymentTransitions;
+use Sylius\PayPalPlugin\Controller\CancelLastPayPalPaymentAction;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class CancelLastPayPalPaymentActionTest extends TestCase
+{
+    private ObjectManager $objectManager;
+
+    private StateMachineInterface $stateMachine;
+
+    private OrderProcessorInterface $orderProcessor;
+
+    private OrderRepositoryInterface $orderRepository;
+
+    private CancelLastPayPalPaymentAction $action;
+
+    protected function setUp(): void
+    {
+        $this->objectManager = $this->createMock(ObjectManager::class);
+        $this->stateMachine = $this->createMock(StateMachineInterface::class);
+        $this->orderProcessor = $this->createMock(OrderProcessorInterface::class);
+        $this->orderRepository = $this->createMock(OrderRepositoryInterface::class);
+
+        $this->action = new CancelLastPayPalPaymentAction(
+            $this->objectManager,
+            $this->stateMachine,
+            $this->orderProcessor,
+            $this->orderRepository,
+        );
+    }
+
+    public function testReturnNoContentWhenPaymentCannotBeCancelled(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $payment = $this->createMock(PaymentInterface::class);
+        $request = new Request();
+        $request->attributes->set('token', 'order-token');
+
+        $this->orderRepository
+            ->expects($this->once())
+            ->method('findOneByTokenValue')
+            ->with('order-token')
+            ->willReturn($order)
+        ;
+
+        $order->expects($this->once())->method('getLastPayment')->willReturn($payment);
+
+        $this->stateMachine
+            ->expects($this->once())
+            ->method('can')
+            ->with($payment, PaymentTransitions::GRAPH, PaymentTransitions::TRANSITION_CANCEL)
+            ->willReturn(false)
+        ;
+
+        $this->stateMachine->expects($this->never())->method('apply');
+        $this->objectManager->expects($this->never())->method('flush');
+
+        $response = ($this->action)($request);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertEquals('', $response->getContent());
+    }
+
+    public function testCancelPaymentWhenTransitionIsPossible(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $payment = $this->createMock(PaymentInterface::class);
+        $lastPayment = $this->createMock(PaymentInterface::class);
+        $request = new Request();
+        $request->attributes->set('token', 'order-token');
+
+        $this->orderRepository
+            ->expects($this->once())
+            ->method('findOneByTokenValue')
+            ->with('order-token')
+            ->willReturn($order)
+        ;
+
+        $order->expects($this->exactly(2))->method('getLastPayment')->willReturn($payment, $lastPayment);
+
+        $this->stateMachine
+            ->expects($this->once())
+            ->method('can')
+            ->with($payment, PaymentTransitions::GRAPH, PaymentTransitions::TRANSITION_CANCEL)
+            ->willReturn(true)
+        ;
+
+        $this->stateMachine
+            ->expects($this->once())
+            ->method('apply')
+            ->with($payment, PaymentTransitions::GRAPH, PaymentTransitions::TRANSITION_CANCEL)
+        ;
+
+        $lastPayment->expects($this->once())->method('getState')->willReturn(PaymentInterface::STATE_CART);
+
+        $this->orderProcessor->expects($this->once())->method('process')->with($order);
+        $this->objectManager->expects($this->once())->method('flush');
+
+        $response = ($this->action)($request);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertEquals('', $response->getContent());
+    }
+
+    public function testSkipOrderProcessingWhenLastPaymentIsNew(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $payment = $this->createMock(PaymentInterface::class);
+        $lastPayment = $this->createMock(PaymentInterface::class);
+        $request = new Request();
+        $request->attributes->set('token', 'order-token');
+
+        $this->orderRepository
+            ->expects($this->once())
+            ->method('findOneByTokenValue')
+            ->with('order-token')
+            ->willReturn($order)
+        ;
+
+        $order->expects($this->exactly(2))->method('getLastPayment')->willReturn($payment, $lastPayment);
+
+        $this->stateMachine
+            ->expects($this->once())
+            ->method('can')
+            ->with($payment, PaymentTransitions::GRAPH, PaymentTransitions::TRANSITION_CANCEL)
+            ->willReturn(true)
+        ;
+
+        $this->stateMachine
+            ->expects($this->once())
+            ->method('apply')
+            ->with($payment, PaymentTransitions::GRAPH, PaymentTransitions::TRANSITION_CANCEL)
+        ;
+
+        $lastPayment->expects($this->once())->method('getState')->willReturn(PaymentInterface::STATE_NEW);
+
+        $this->orderProcessor->expects($this->never())->method('process');
+        $this->objectManager->expects($this->once())->method('flush');
+
+        $response = ($this->action)($request);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertEquals('', $response->getContent());
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7 (fixes)
| Bug fix?        | yes

Solves problems
- during the order process using ‘PayPal checkout’ two payments are created;
- when the customer clicks on PayPal checkout, he is not taken to the -Complete step with his PayPal account details, but to the Select Address step;
- When changing the PayPal settings in payment methods, the hidden data in the form are deleted.