### PR TITLE
Fix/configuration and payment process

### DIFF
--- a/src/Controller/ProcessPayPalOrderAction.php
+++ b/src/Controller/ProcessPayPalOrderAction.php
@@ -19,7 +19,6 @@ use Sylius\Abstraction\StateMachine\StateMachineInterface;
 use Sylius\Abstraction\StateMachine\WinzouStateMachineAdapter;
 use Sylius\Component\Core\Factory\AddressFactoryInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
-use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\Component\Core\OrderCheckoutTransitions;
@@ -89,10 +88,6 @@ final class ProcessPayPalOrderAction
         $orderId = $request->request->getInt('orderId');
         $order = $this->orderProvider->provideOrderById($orderId);
 
-        if ($order->getState() !== OrderInterface::STATE_NEW) {
-            return new JsonResponse(['orderID' => $orderId]);
-        }
-
         /** @var PaymentInterface|null $payment */
         $payment = $order->getLastPayment(PaymentInterface::STATE_CART);
 
@@ -156,9 +151,6 @@ final class ProcessPayPalOrderAction
 
             return new JsonResponse(['orderID' => $orderId]);
         }
-
-        $this->paymentStateManager->create($payment);
-        $this->paymentStateManager->process($payment);
 
         return new JsonResponse(['orderID' => $orderId]);
     }

--- a/src/Form/Type/PayPalConfigurationType.php
+++ b/src/Form/Type/PayPalConfigurationType.php
@@ -17,21 +17,54 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 
 final class PayPalConfigurationType extends AbstractType
 {
+    private const HIDDEN_FIELDS = [
+        'merchant_id',
+        'sylius_merchant_id',
+        'partner_attribution_id',
+        'use_authorize',
+    ];
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        $originalData = [];
+
         $builder
-            ->add('client_id', TextType::class, ['label' => 'sylius.pay_pal.client_id', 'attr' => ['readonly' => true]])
-            ->add('client_secret', TextType::class, ['label' => 'sylius.pay_pal.client_secret', 'attr' => ['readonly' => true]])
-            ->add('merchant_id', HiddenType::class, ['label' => 'sylius.pay_pal.client_secret', 'attr' => ['readonly' => true]])
-            ->add('sylius_merchant_id', HiddenType::class, ['label' => 'sylius.pay_pal.client_secret', 'attr' => ['readonly' => true]])
-            ->add('partner_attribution_id', HiddenType::class, ['label' => 'sylius.pay_pal.partner_attribution_id', 'attr' => ['readonly' => true]])
+            ->add('client_id', TextType::class, ['label' => 'sylius_paypal.client_id', 'attr' => ['readonly' => true]])
+            ->add('client_secret', TextType::class, ['label' => 'sylius_paypal.client_secret', 'attr' => ['readonly' => true]])
+            ->add('merchant_id', HiddenType::class, ['label' => 'sylius_paypal.client_secret', 'attr' => ['readonly' => true]])
+            ->add('sylius_merchant_id', HiddenType::class, ['label' => 'sylius_paypal.client_secret', 'attr' => ['readonly' => true]])
+            ->add('partner_attribution_id', HiddenType::class, ['label' => 'sylius_paypal.partner_attribution_id', 'attr' => ['readonly' => true]])
             // we need to force Sylius Payum integration to postpone creating an order, it's the easiest way
             ->add('use_authorize', HiddenType::class, ['data' => true, 'attr' => ['readonly' => true]])
-            ->add('reports_sftp_username', TextType::class, ['label' => 'sylius.pay_pal.sftp_username', 'required' => false])
-            ->add('reports_sftp_password', TextType::class, ['label' => 'sylius.pay_pal.sftp_password', 'required' => false])
+            ->add('reports_sftp_username', TextType::class, ['label' => 'sylius_paypal.sftp_username', 'required' => false])
+            ->add('reports_sftp_password', TextType::class, ['label' => 'sylius_paypal.sftp_password', 'required' => false])
         ;
+
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use (&$originalData): void {
+            $data = $event->getData();
+            if (is_array($data)) {
+                $originalData = $data;
+            }
+        });
+
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) use (&$originalData): void {
+            $submitted = $event->getData() ?? [];
+
+            foreach (self::HIDDEN_FIELDS as $field) {
+                if (
+                    !array_key_exists($field, $submitted) &&
+                    array_key_exists($field, $originalData)
+                ) {
+                    $submitted[$field] = $originalData[$field];
+                }
+            }
+
+            $event->setData($submitted);
+        });
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7 (fixes)
| Bug fix?        | yes

Solves problems
- when the customer clicks on PayPal checkout, he is not taken to the -Complete step with his PayPal account details, but to the Select Address step;
- When changing the PayPal settings in payment methods, the hidden data in the form are deleted.
