### PR TITLE
Fixes incorrect dependency on sylius/resource-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "psr/http-client-implementation": "~1.0",
         "psr/http-factory-implementation": "~1.0",
         "sylius-labs/doctrine-migrations-extra-bundle": "^0.1.4 || ^0.2",
+        "sylius/resource-bundle": "^1.11",
         "sylius/sylius": "~1.13.0 || ~1.14.0",
         "symfony/mailer": "^5.4.21 || ^6.4"
     },


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7 (bug fixes)
| Bug fix?        | yes
| New feature?    | no
| Related tickets | fixes [#359](https://github.com/Sylius/PayPalPlugin/issues/359)

Added "sylius/resource-bundle": "^1.11" dependency to composer.json