### PR TITLE
Prevent cart from being cleared when PayPal Express checkout is canceled

### DIFF
--- a/src/Controller/CancelPayPalOrderAction.php
+++ b/src/Controller/CancelPayPalOrderAction.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sylius\PayPalPlugin\Controller;
 
-use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\PayPalPlugin\Provider\FlashBagProvider;
 use Sylius\PayPalPlugin\Provider\PaymentProviderInterface;
@@ -46,19 +45,6 @@ final class CancelPayPalOrderAction
 
     public function __invoke(Request $request): Response
     {
-        /**
-         * @var string $content
-         */
-        $content = $request->getContent();
-
-        $content = (array) json_decode($content, true);
-
-        $payment = $this->paymentProvider->getByPayPalOrderId((string) $content['payPalOrderId']);
-
-        /** @var OrderInterface $order */
-        $order = $payment->getOrder();
-        $this->orderRepository->remove($order);
-
         FlashBagProvider::getFlashBag($this->flashBagOrRequestStack)->add('success', 'sylius.pay_pal.order_cancelled');
 
         return new Response('', Response::HTTP_NO_CONTENT);


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7 (bug fixes)
| Bug fix?        | yes
| New feature?    | no
| Related tickets | fixes #354 

This PR addresses an issue where the shopping cart is emptied when a customer initiates but cancels a PayPal Checkout.

