### PR TITLE
Truncate product name to fit PayPal API limits (max 127 characters)

### DIFF
--- a/src/Provider/PayPalItemDataProvider.php
+++ b/src/Provider/PayPalItemDataProvider.php
@@ -45,9 +45,13 @@ final class PayPalItemDataProvider implements PayPalItemDataProviderInterface
                 $itemValue = $orderItem->getUnitPrice();
                 $itemData['total_item_value'] += ($itemValue * $displayQuantity) / 100;
                 $itemData['total_tax'] += ($nonNeutralTax * $displayQuantity) / 100;
+                $productName = $orderItem->getProductName();
+                $productName = mb_strlen($productName) > 127
+                    ? mb_substr($productName, 0, 124) . '...'
+                    : $productName;
 
                 $itemData['items'][] = [
-                    'name' => $orderItem->getProductName(),
+                    'name' => $productName,
                     'unit_amount' => [
                         'value' => number_format($itemValue / 100, 2, '.', ''),
                         'currency_code' => $order->getCurrencyCode(),


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7 (bug fixes)
| Bug fix?        | yes
| New feature?    | no
| Related tickets | fixes https://github.com/Sylius/PayPalPlugin/issues/332

This PR ensures product names sent to PayPal do not exceed the 127-character limit defined by the PayPal Orders API. If the name is too long, it will be truncated to 124 characters and appended with an ellipsis (...). This prevents potential validation issues and ensures clean display of item data in the PayPal interface.
