### PR TITLE
[Checkout] Fix supported locales resolving

### DIFF
--- a/spec/Processor/LocaleProcessorSpec.php
+++ b/spec/Processor/LocaleProcessorSpec.php
@@ -14,9 +14,22 @@ declare(strict_types=1);
 namespace spec\Sylius\PayPalPlugin\Processor;
 
 use PhpSpec\ObjectBehavior;
+use Sylius\PayPalPlugin\Resolver\SupportedLocaleResolverInterface;
 
 final class LocaleProcessorSpec extends ObjectBehavior
 {
+    function let(SupportedLocaleResolverInterface $supportedLocaleResolver): void
+    {
+        $supportedLocaleResolver->resolve('et')->willReturn('et_EE');
+        $supportedLocaleResolver->resolve('pl')->willReturn('pl_PL');
+        $supportedLocaleResolver->resolve('ja')->willReturn('ja_JP');
+        $supportedLocaleResolver->resolve('it_IT')->willReturn('it_IT');
+        $supportedLocaleResolver->resolve('de_DE')->willReturn('de_DE');
+        $supportedLocaleResolver->resolve('en')->willReturn('en_US');
+
+        $this->beConstructedWith($supportedLocaleResolver);
+    }
+
     function it_always_processes_locale_to_version_with_region(): void
     {
         $this->process('et')->shouldReturn('et_EE');
@@ -27,12 +40,34 @@ final class LocaleProcessorSpec extends ObjectBehavior
     function it_returns_same_locale_if_it_is_valid(): void
     {
         $this->process('it_IT')->shouldReturn('it_IT');
-        $this->process('ja_JP_TRADITIONAL')->shouldReturn('ja_JP_TRADITIONAL');
-        $this->process('sd_Arab_PK')->shouldReturn('sd_Arab_PK');
+        $this->process('de_DE')->shouldReturn('de_DE');
     }
 
     function it_returns_correct_locale_for_en_locale(): void
     {
+        $this->process('en')->shouldReturn('en_US');
+    }
+
+    function it_always_processes_locale_to_version_with_region_using_legacy_mode(): void
+    {
+        $this->beConstructedWith(null);
+        $this->process('et')->shouldReturn('et_EE');
+        $this->process('pl')->shouldReturn('pl_PL');
+        $this->process('ja')->shouldReturn('ja_JP');
+    }
+
+    function it_returns_same_locale_if_it_is_valid_using_legacy_mode(): void
+    {
+        $this->beConstructedWith(null);
+        $this->process('it_IT')->shouldReturn('it_IT');
+        $this->process('de_DE')->shouldReturn('de_DE');
+        $this->process('ja_JP_TRADITIONAL')->shouldReturn('ja_JP_TRADITIONAL');
+        $this->process('sd_Arab_PK')->shouldReturn('sd_Arab_PK');
+    }
+
+    function it_returns_correct_locale_for_en_locale_using_legacy_mode(): void
+    {
+        $this->beConstructedWith(null);
         $this->process('en')->shouldReturn('en_US');
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -18,6 +18,14 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 final class Configuration implements ConfigurationInterface
 {
+    private const ALL_PAYPAL_SUPPORTED_LOCALES = [
+        'ar_EG', 'cs_CZ', 'da_DK', 'de_DE', 'el_GR', 'en_US', 'en_AU', 'en_GB',
+        'en_IN', 'es_ES', 'es_XC', 'fi_FI', 'fr_FR', 'fr_CA', 'fr_XC', 'he_IL',
+        'hu_HU', 'id_ID', 'it_IT', 'ja_JP', 'ko_KR', 'nl_NL', 'no_NO', 'pl_PL',
+        'pt_BR', 'pt_PT', 'ru_RU', 'sk_SK', 'sv_SE', 'th_TH', 'zh_CN', 'zh_HK',
+        'zh_TW', 'zh_XC',
+    ];
+
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sylius_pay_pal_plugin');
@@ -33,6 +41,11 @@ final class Configuration implements ConfigurationInterface
                             ->defaultFalse()
                         ->end()
                     ->end()
+                ->end()
+                ->arrayNode('supported_locales')
+                    ->scalarPrototype()->end()
+                    ->defaultValue(self::ALL_PAYPAL_SUPPORTED_LOCALES)
+                    ->performNoDeepMerging()
                 ->end()
             ->end()
         ;

--- a/src/DependencyInjection/SyliusPayPalExtension.php
+++ b/src/DependencyInjection/SyliusPayPalExtension.php
@@ -34,6 +34,8 @@ final class SyliusPayPalExtension extends Extension implements PrependExtensionI
 
         $this->setCommunicationParameters($container, $config);
 
+        $container->setParameter('sylius_paypal.supported_locales', $config['supported_locales']);
+
         $loaderResolver = new LoaderResolver([
             new PhpFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config')),
             new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config')),

--- a/src/Processor/LocaleProcessor.php
+++ b/src/Processor/LocaleProcessor.php
@@ -13,13 +13,46 @@ declare(strict_types=1);
 
 namespace Sylius\PayPalPlugin\Processor;
 
+use Sylius\PayPalPlugin\Resolver\SupportedLocaleResolverInterface;
 use Symfony\Component\Intl\Locales;
 
 final class LocaleProcessor implements LocaleProcessorInterface
 {
+    private const ALLOWED_LOCALE_PATTERN = '/^[a-z]{2}(_[A-Z]{2})?$/';
+
+    public function __construct(
+        private readonly ?SupportedLocaleResolverInterface $supportedLocaleResolver = null,
+    ) {
+        if (null === $this->supportedLocaleResolver) {
+            trigger_deprecation(
+                'sylius/paypal-plugin',
+                '1.7',
+                sprintf(
+                    'Not passing an instance of "%s" is deprecated and will be prohibited in 3.0',
+                    SupportedLocaleResolverInterface::class,
+                ),
+            );
+        }
+    }
+
     public function process(string $locale): string
     {
-        if ($this->isValidLocale($locale)) {
+        if (null !== $this->supportedLocaleResolver) {
+            $locale = trim($locale);
+
+            if ($this->isValidLocale($locale)) {
+                return $this->supportedLocaleResolver->resolve($locale);
+            }
+
+            throw new \UnexpectedValueException(sprintf('Locale "%s" is not valid.', $locale));
+        }
+
+        return $this->legacyProcess($locale);
+    }
+
+    private function legacyProcess(string $locale): string
+    {
+        if (str_contains($locale, '_')) {
             return $locale;
         }
 
@@ -29,9 +62,9 @@ final class LocaleProcessor implements LocaleProcessorInterface
 
         $locales = array_filter(Locales::getLocales(), function (string $targetLocale) use ($locale): bool {
             return
-                strpos($targetLocale, $locale) === 0 &&
-                strpos($targetLocale, '_') !== false &&
-                strlen($targetLocale) === 5
+                str_starts_with($targetLocale, $locale) &&
+                strlen($targetLocale) === 5 &&
+                $this->isValidLocale($targetLocale)
             ;
         });
 
@@ -39,11 +72,14 @@ final class LocaleProcessor implements LocaleProcessorInterface
             throw new \UnexpectedValueException(sprintf('Locale "%s" is not supported by PayPal.', $locale));
         }
 
-        return $locales[array_key_first($locales)];
+        return array_shift($locales);
     }
 
     private function isValidLocale(string $locale): bool
     {
-        return strpos($locale, '_') !== false;
+        return
+            false === str_contains($locale, ' ') &&
+            1 === preg_match(self::ALLOWED_LOCALE_PATTERN, $locale)
+        ;
     }
 }

--- a/src/Resolver/SupportedLocaleResolver.php
+++ b/src/Resolver/SupportedLocaleResolver.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PayPalPlugin\Resolver;
+
+final class SupportedLocaleResolver implements SupportedLocaleResolverInterface
+{
+    private readonly array $supportedLocales;
+
+    public function __construct(
+        array $supportedLocales = [],
+    ) {
+        $this->supportedLocales = array_unique($supportedLocales);
+    }
+
+    public function resolve(string $locale): string
+    {
+        if (empty(trim($locale))) {
+            throw new \UnexpectedValueException('Locale cannot be empty.');
+        }
+
+        $length = strlen($locale);
+        if (5 === $length) {
+            if (in_array($locale, $this->supportedLocales, true)) {
+                return $locale;
+            }
+
+            throw new \UnexpectedValueException(
+                sprintf('Locale "%s" is not supported by PayPal.', $locale),
+            );
+        }
+        if (2 === $length) {
+            return $this->findSupportedLocaleByLanguageCode($locale);
+        }
+
+        throw new \UnexpectedValueException(
+            sprintf('Locale "%s" is not supported by PayPal.', $locale),
+        );
+    }
+
+    private function findSupportedLocaleByLanguageCode(string $languageCode): string
+    {
+        foreach ($this->supportedLocales as $locale) {
+            if (str_starts_with($locale, $languageCode)) {
+                return $locale;
+            }
+        }
+
+        throw new \UnexpectedValueException(
+            sprintf('Language "%s" could not be resolved into a locale supported by PayPal.', $languageCode),
+        );
+    }
+}

--- a/src/Resolver/SupportedLocaleResolverInterface.php
+++ b/src/Resolver/SupportedLocaleResolverInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PayPalPlugin\Resolver;
+
+interface SupportedLocaleResolverInterface
+{
+    /** @throw \UnexpectedValueException */
+    public function resolve(string $locale): string;
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -356,5 +356,13 @@
             <argument type="service" id="sylius.repository.payment_method" />
         </service>
         <service id="Sylius\PayPalPlugin\Resolver\PayPalPaymentMethodsResolverInterface" alias="sylius_paypal.resolver.paypal_payment_methods" />
+
+        <service
+            id="sylius_paypal.resolver.supported_locale"
+            class="Sylius\PayPalPlugin\Resolver\SupportedLocaleResolver"
+        >
+            <argument>%sylius_paypal.supported_locales%</argument>
+        </service>
+        <service id="Sylius\PayPalPlugin\Resolver\SupportedLocaleResolverInterface" alias="sylius_paypal.resolver.supported_locale" />
     </services>
 </container>

--- a/tests/Unit/Resolver/SupportedLocaleResolverTest.php
+++ b/tests/Unit/Resolver/SupportedLocaleResolverTest.php
@@ -1,0 +1,151 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\PayPalPlugin\Unit\Resolver;
+
+use PHPUnit\Framework\TestCase;
+use Sylius\PayPalPlugin\Resolver\SupportedLocaleResolver;
+
+final class SupportedLocaleResolverTest extends TestCase
+{
+    /** @dataProvider validFiveCharacterLocaleProvider */
+    public function test_returns_exact_match_for_five_character_locale(string $locale, array $supportedLocales): void
+    {
+        $resolver = new SupportedLocaleResolver($supportedLocales);
+
+        $result = $resolver->resolve($locale);
+
+        $this->assertSame($locale, $result);
+    }
+
+    /** @return \Generator<string, array<string|array<string>>> */
+    public static function validFiveCharacterLocaleProvider(): \Generator
+    {
+        yield 'en_US' => ['en_US', ['en_US', 'fr_FR', 'de_DE']];
+        yield 'fr_FR' => ['fr_FR', ['en_US', 'fr_FR', 'de_DE']];
+        yield 'de_DE' => ['de_DE', ['en_US', 'fr_FR', 'de_DE']];
+    }
+
+    /** @dataProvider unsupportedFiveCharacterLocaleProvider */
+    public function test_throws_for_unsupported_five_character_locale(string $locale, array $supportedLocales): void
+    {
+        $resolver = new SupportedLocaleResolver($supportedLocales);
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage(sprintf('Locale "%s" is not supported by PayPal.', $locale));
+
+        $resolver->resolve($locale);
+    }
+
+    /** @return \Generator<string, array<string|array<string>>> */
+    public static function unsupportedFiveCharacterLocaleProvider(): \Generator
+    {
+        yield 'es_ES not in list' => ['es_ES', ['en_US', 'fr_FR', 'de_DE']];
+        yield 'it_IT not in list' => ['it_IT', ['en_US', 'fr_FR']];
+        yield 'pt_PT not in list' => ['pt_PT', ['en_GB', 'en_US']];
+    }
+
+    /** @dataProvider validLanguageCodeProvider */
+    public function test_resolves_two_character_language_code_to_supported_locale(string $languageCode, array $supportedLocales, string $expectedLocale): void
+    {
+        $resolver = new SupportedLocaleResolver($supportedLocales);
+
+        $result = $resolver->resolve($languageCode);
+
+        $this->assertSame($expectedLocale, $result);
+    }
+
+    /** @return \Generator<string, array<string|array<string>>> */
+    public static function validLanguageCodeProvider(): \Generator
+    {
+        yield 'en finds en_US' => ['en', ['en_US', 'en_GB', 'fr_FR', 'de_DE'], 'en_US'];
+        yield 'de finds de_DE' => ['de', ['de_DE', 'de_AT', 'fr_FR'], 'de_DE'];
+        yield 'fr finds fr_FR' => ['fr', ['en_US', 'fr_FR', 'de_DE'], 'fr_FR'];
+    }
+
+    /** @dataProvider unsupportedLanguageCodeProvider */
+    public function test_throws_when_language_code_not_found(string $languageCode, array $supportedLocales): void
+    {
+        $resolver = new SupportedLocaleResolver($supportedLocales);
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage(sprintf('Language "%s" could not be resolved into a locale supported by PayPal.', $languageCode));
+
+        $resolver->resolve($languageCode);
+    }
+
+    /** @return \Generator<string, array<string|array<string>>> */
+    public static function unsupportedLanguageCodeProvider(): \Generator
+    {
+        yield 'es not in list' => ['es', ['en_US', 'fr_FR', 'de_DE']];
+        yield 'it not in list' => ['it', ['en_US', 'fr_FR']];
+        yield 'pt not in list' => ['pt', ['en_GB', 'en_US']];
+    }
+
+    /** @dataProvider invalidLocaleProvider */
+    public function test_throws_for_invalid_locale_length(string $locale, array $supportedLocales): void
+    {
+        $resolver = new SupportedLocaleResolver($supportedLocales);
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage(sprintf('Locale "%s" is not supported by PayPal.', $locale));
+
+        $resolver->resolve($locale);
+    }
+
+    /** @return \Generator<string, array<string|array<string>>> */
+    public static function invalidLocaleProvider(): \Generator
+    {
+        yield 'three character locale' => ['eng', ['en_US', 'fr_FR']];
+        yield 'six character locale' => ['en_US_X', ['en_US', 'fr_FR']];
+        yield 'four character locale' => ['enUS', ['en_US', 'fr_FR']];
+    }
+
+    public function test_throws_for_empty_locale(): void
+    {
+        $resolver = new SupportedLocaleResolver(['en_US', 'fr_FR']);
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('Locale cannot be empty.');
+
+        $resolver->resolve('');
+    }
+
+    public function test_constructor_removes_duplicate_locales(): void
+    {
+        $supportedLocales = ['en_US', 'fr_FR', 'en_GB', 'de_DE', 'fr_FR'];
+        $resolver = new SupportedLocaleResolver($supportedLocales);
+
+        $result = $resolver->resolve('en');
+        $this->assertSame('en_US', $result);
+    }
+
+    /** @dataProvider emptyLocaleProvider */
+    public function test_throws_with_empty_locale(string $locale): void
+    {
+        $supportedLocales = ['en_US', 'fr_FR', 'en_US', 'de_DE', 'fr_FR'];
+        $resolver = new SupportedLocaleResolver($supportedLocales);
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('Locale cannot be empty.');
+
+        $resolver->resolve($locale);
+    }
+
+    /** @return \Generator<string, array<array<string>>> */
+    public static function emptyLocaleProvider(): \Generator
+    {
+        yield 'empty' => [''];
+        yield 'space' => [' '];
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7
| Bug fix?        | yes
| New feature?    | kinda
| Related tickets | fixes #207

Introduced a new configuration node `supported_locales` which sets the `sylius_paypal.supported_locales` parameter, further used in locale processing.
The default value of this node is set based on [PayPal's documentation](https://developer.paypal.com/reference/locale-codes/) table.