### PR TITLE
fix(di): use phpseclib3 instead of phpseclib

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -252,7 +252,7 @@
         />
         <service id="sylius_paypal.provider.uuid" alias="Sylius\PayPalPlugin\Provider\UuidProviderInterface" />
 
-        <service id="sylius.paypal.client.sftp" class="phpseclib\Net\SFTP">
+        <service id="sylius.paypal.client.sftp" class="phpseclib3\Net\SFTP">
             <argument>%sylius_paypal.reports_sftp_host%</argument>
         </service>
         <service id="sylius_paypal.client.sftp" alias="sylius.paypal.client.sftp" />


### PR DESCRIPTION
Hello,

On the version 1.7.6 for Sylius 1 there is a little error on DI for service `sylius.paypal.client.sftp`, the class is `phpseclib\Net\SFTP` but the `Sylius\PayPalPlugin\Downloader\SftpPayoutsReportDownloader` use  `phpseclib3\Net\SFTP`

This cause the error on report download :
```
Attempted to load class "SFTP" from namespace "phpseclib\Net".
Did you forget a "use" statement for "phpseclib3\Net\SFTP"? 
``` 
Kind regards,
Kévin 
