### PR TITLE
Add telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,8 @@ Sylius Core Team’s plugin for [PayPal Commerce Platform](https://www.paypal.co
 * `1.5` (v1.5.*) - security fixes
 * `1.6` (v1.6.*) - bug fixes, improvements
 * `1.7` (v1.7.*) - new features
+
+## Telemetry
+
+This plugin enforces telemetry data collection when used with Sylius.
+Details are described in [TELEMETRY_POLICY.md](./TELEMETRY_POLICY.md).

--- a/TELEMETRY_POLICY.md
+++ b/TELEMETRY_POLICY.md
@@ -1,0 +1,69 @@
+# Telemetry Policy
+
+## Applicability
+
+This Telemetry Policy applies to the use of this plugin in combination with Sylius.
+
+By installing or using this plugin with Sylius, the user acknowledges that telemetry data is collected and transmitted as described in this document.
+
+---
+
+## Mandatory telemetry
+
+Telemetry data collection is mandatory when this plugin is used.
+
+While this plugin is installed and active, Sylius telemetry operates under the conditions defined by this plugin and cannot be disabled independently.
+Telemetry behavior outside of this scope follows the standard Sylius configuration.
+
+---
+
+## Scope of collected data
+
+Telemetry is limited to non-identifying technical data, which may include:
+
+- Sylius version
+- plugin version
+- PHP version and selected dependency versions
+- identifiers of installed and enabled plugins
+- runtime environment classification (production or non-production)
+
+Telemetry does not include, and is not intended to include:
+
+- personal data
+- customer data
+- order data
+- product data
+- business, transactional, or confidential information
+- authentication credentials or secrets
+
+A detailed description of the Sylius telemetry mechanism is available in the public issue:
+https://github.com/Sylius/Sylius/issues/18588
+
+---
+
+## Purpose and use of telemetry data
+
+Telemetry data is collected for the purpose of:
+
+- understanding usage patterns within the Sylius ecosystem
+- analyzing the adoption and frequency of plugin usage
+- identifying commonly used versions of Sylius and plugins
+- supporting maintenance, compatibility, and future development efforts
+
+Telemetry data is processed in aggregated form and is not used to identify individual users, installations, or businesses.
+
+---
+
+## Licensing
+
+This plugin is distributed under the MIT license.
+
+Telemetry collection constitutes part of the technical operation of the software and does not alter, restrict, or supplement the rights granted under the license.
+
+---
+
+## Changes to this policy
+
+This Telemetry Policy may be updated to reflect changes in telemetry implementation, legal requirements, or operational practices.
+
+Updated versions of this policy will be made available in the plugin repository.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,10 @@
 {
     "name": "sylius/paypal-plugin",
     "type": "sylius-plugin",
-    "keywords": ["sylius", "sylius-plugin"],
+    "keywords": [
+        "sylius",
+        "sylius-plugin"
+    ],
     "description": "PayPal plugin for Sylius.",
     "license": "MIT",
     "require": {
@@ -15,6 +18,7 @@
         "sylius-labs/doctrine-migrations-extra-bundle": "^0.1.4 || ^0.2",
         "sylius/resource-bundle": "^1.11",
         "sylius/sylius": "~1.13.0 || ~1.14.0",
+        "sylius/telemetry": "^1.0",
         "symfony/mailer": "^5.4.21 || ^6.4"
     },
     "require-dev": {
@@ -55,7 +59,9 @@
         }
     },
     "autoload-dev": {
-        "classmap": ["tests/Application/Kernel.php"]
+        "classmap": [
+            "tests/Application/Kernel.php"
+        ]
     },
     "config": {
         "sort-packages": true,

--- a/src/SyliusPayPalPlugin.php
+++ b/src/SyliusPayPalPlugin.php
@@ -14,9 +14,17 @@ declare(strict_types=1);
 namespace Sylius\PayPalPlugin;
 
 use Sylius\Bundle\CoreBundle\Application\SyliusPluginTrait;
+use Sylius\Telemetry\TelemetryCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 final class SyliusPayPalPlugin extends Bundle
 {
     use SyliusPluginTrait;
+
+    public function build(ContainerBuilder $container): void
+    {
+        parent::build($container);
+        $container->addCompilerPass(new TelemetryCompilerPass());
+    }
 }


### PR DESCRIPTION
Adds telemetry policy and `sylius/telemetry-bundle` as a hard dependency.

- `TELEMETRY_POLICY.md` — describes scope, purpose, and conditions of telemetry data collection
- `composer.json` — requires `sylius/telemetry-bundle: ^1.0`
- `README.md` — telemetry notice pointing to the policy file

Related: https://github.com/Sylius/Sylius/issues/18588