### PR TITLE
Add null check for gatewayConfig

### DIFF
--- a/src/Form/Extension/PaymentMethodTypeExtension.php
+++ b/src/Form/Extension/PaymentMethodTypeExtension.php
@@ -32,8 +32,12 @@ final class PaymentMethodTypeExtension extends AbstractTypeExtension
             $data = $event->getData();
             $form = $event->getForm();
 
-            /** @var GatewayConfigInterface $gatewayConfig */
+            /** @var GatewayConfigInterface|null $gatewayConfig */
             $gatewayConfig = $data->getGatewayConfig();
+            if ($gatewayConfig === null) {
+                return;
+            }
+
             if ($gatewayConfig->getFactoryName() === SyliusPayPalExtension::PAYPAL_FACTORY_NAME) {
                 $form->add('enabled', HiddenType::class, [
                     'required' => false,


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 2.0 (bug fixes, improvements)
| Bug fix?        | "yes"
| New feature?    | no
| Related tickets | -

This is not really a "direct" bug fix but more of a "indirect" bug fix, if we can call it like that 😅
Btw, this change is necessary when the Payment Method form of the admin is tagged as a `sylius.live_component.admin` instead of the default `sylius.component.admin`, like the Shipment Method form for example. You want to do this for example if you have a customization where you can configure some fees for each channel, and to do this you have to make it a Live component.
Sadly, out of the box, this will throw an error 'cause when the Live component re-renders it creates and empty Payment Method that has no gateway config and it pass from the PRE_SET_DATA of this extension and fails.
I know that is due to the fact that we made the payment method a live component with a customization, but it's probably something that this plugin should handle out of the box. What do you think?