### PR TITLE
[BugFix] Fix PayPal Sandbox modal form submitting to wrong URL

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
             matrix:
                 php: ["8.2", "8.3"]
                 symfony: ["^6.4", "^7.4"]
-                sylius: ["~2.0.1", "~2.1.0", "~2.2.0"]
+                sylius: ["~2.1.0", "~2.2.0"]
                 database: ["mysql:8.4", "postgres:16"]
                 node: ["22.x"]
                 state_machine_adapter: ["symfony_workflow"]
@@ -40,8 +40,8 @@ jobs:
                 include:
                     -
                         php: "8.3"
-                        symfony: "~7.3.0"
-                        sylius: "~2.1.0"
+                        symfony: "^7.4"
+                        sylius: "~2.2.0"
                         node: "24.x"
                         database: "mysql:8.4"
                         state_machine_adapter: "winzou_state_machine"
@@ -128,7 +128,7 @@ jobs:
                 uses: actions/upload-artifact@v4
                 if: failure()
                 with:
-                    name: "Behat logs - Sylius ${{ matrix.sylius }}, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, ${{ matrix.database }}"
+                    name: "Behat logs - Sylius ${{ matrix.sylius }}, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, ${{ env.DB_TYPE }} ${{ env.DB_VERSION }}"
                     path: etc/build/
                     if-no-files-found: ignore
                     compression-level: 6

--- a/assets/admin/entrypoint.js
+++ b/assets/admin/entrypoint.js
@@ -1,0 +1,1 @@
+import './scripts/live-component-modal-portal';

--- a/assets/admin/scripts/live-component-modal-portal.js
+++ b/assets/admin/scripts/live-component-modal-portal.js
@@ -1,0 +1,41 @@
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+const SANDBOX_MODAL_COMPONENT_NAME = 'sylius_paypal_sandbox_modal';
+
+function getSandboxModalWrapper(modal) {
+    const parent = modal.parentElement;
+
+    if (
+        parent === null ||
+        parent === document.body ||
+        parent.getAttribute('data-live-name-value') !== SANDBOX_MODAL_COMPONENT_NAME
+    ) {
+        return null;
+    }
+
+    return parent;
+}
+
+function portalSandboxModal(event) {
+    const wrapper = getSandboxModalWrapper(event.target);
+
+    if (wrapper === null) {
+        return;
+    }
+
+    const placeholder = document.createComment(SANDBOX_MODAL_COMPONENT_NAME);
+    wrapper.before(placeholder);
+    document.body.appendChild(wrapper);
+
+    event.target.addEventListener('hidden.bs.modal', () => placeholder.replaceWith(wrapper), { once: true });
+    event.stopImmediatePropagation();
+}
+
+document.addEventListener('show.bs.modal', portalSandboxModal, { capture: true });

--- a/features/sorting_payment_method_selection.feature
+++ b/features/sorting_payment_method_selection.feature
@@ -12,11 +12,11 @@ Feature: Prioritising PayPal payment method during checkout
         And the store allows paying with "Cash on Delivery" at position 2
         And the store allows paying with "Offline" at position 1
         And the store allows paying with "PayPal" with "PayPal" factory name at position 4
-        And I am a logged in customer
 
     @ui
     Scenario: Seeing payment methods sorted
-        Given I have product "Targaryen T-Shirt" in the cart
+        Given I am a logged in customer
+        And the customer has product "Targaryen T-Shirt" in the cart
         When I am at the checkout addressing step
         And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step

--- a/src/Twig/Component/PayPalSandboxModalComponent.php
+++ b/src/Twig/Component/PayPalSandboxModalComponent.php
@@ -88,4 +88,9 @@ final class PayPalSandboxModalComponent
     {
         return $this->formFactory->create(PayPalSandboxCredentialsType::class);
     }
+
+    protected function getDataModelValue(): string
+    {
+        return 'norender|on(change)|*';
+    }
 }

--- a/tests/Behat/Resources/suites.yml
+++ b/tests/Behat/Resources/suites.yml
@@ -9,6 +9,7 @@ default:
                 - sylius.behat.context.hook.mailer
 
                 - sylius.behat.context.transform.address
+                - sylius.behat.context.transform.cart
                 - sylius.behat.context.transform.country
                 - sylius.behat.context.transform.channel
                 - sylius.behat.context.transform.currency


### PR DESCRIPTION
Sylius AdminBundle's modal-portal.js moves .modal elements to <body> on show.bs.modal. When the .modal lived inside a LiveComponent wrapper div (which carries data-controller="live"), only the modal was relocated, detaching it from its Stimulus ancestor. This broke the data-action="live#action:prevent" binding on the sandbox credentials form, causing a plain HTTP POST to the current page URL instead of an AJAX request to the LiveComponent endpoint, resulting in a MethodNotAllowedHttpException.
| Q               | A
| --------------- | -----
| Branch?         | 2.1 (new features)
| Bug fix?        | yes
| New feature?    | no
