### PR TITLE
[BugFix] Fix PayPal sandbox modal LiveComponent DOM detachment

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,8 +46,8 @@ jobs:
 
                     -
                         php: "8.3"
-                        symfony: "~7.3.0"
-                        sylius: "~2.1.0"
+                        symfony: "^7.4"
+                        sylius: "~2.2.0"
                         node: "24.x"
                         database: "postgres"
                         postgres: "15.8"

--- a/assets/admin/entrypoint.js
+++ b/assets/admin/entrypoint.js
@@ -1,0 +1,1 @@
+import './scripts/live-component-modal-portal';

--- a/assets/admin/scripts/live-component-modal-portal.js
+++ b/assets/admin/scripts/live-component-modal-portal.js
@@ -1,0 +1,41 @@
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+const SANDBOX_MODAL_COMPONENT_NAME = 'sylius_paypal_sandbox_modal';
+
+function getSandboxModalWrapper(modal) {
+    const parent = modal.parentElement;
+
+    if (
+        parent === null ||
+        parent === document.body ||
+        parent.getAttribute('data-live-name-value') !== SANDBOX_MODAL_COMPONENT_NAME
+    ) {
+        return null;
+    }
+
+    return parent;
+}
+
+function portalSandboxModal(event) {
+    const wrapper = getSandboxModalWrapper(event.target);
+
+    if (wrapper === null) {
+        return;
+    }
+
+    const placeholder = document.createComment(SANDBOX_MODAL_COMPONENT_NAME);
+    wrapper.before(placeholder);
+    document.body.appendChild(wrapper);
+
+    event.target.addEventListener('hidden.bs.modal', () => placeholder.replaceWith(wrapper), { once: true });
+    event.stopImmediatePropagation();
+}
+
+document.addEventListener('show.bs.modal', portalSandboxModal, { capture: true });

--- a/features/sorting_payment_method_selection.feature
+++ b/features/sorting_payment_method_selection.feature
@@ -12,11 +12,11 @@ Feature: Prioritising PayPal payment method during checkout
         And the store allows paying with "Cash on Delivery" at position 2
         And the store allows paying with "Offline" at position 1
         And the store allows paying with "PayPal" with "PayPal" factory name at position 4
-        And I am a logged in customer
 
     @ui
     Scenario: Seeing payment methods sorted
-        Given I have product "Targaryen T-Shirt" in the cart
+        Given I am a logged in customer
+        And the customer has product "Targaryen T-Shirt" in the cart
         When I am at the checkout addressing step
         And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step

--- a/src/Twig/Component/PayPalSandboxModalComponent.php
+++ b/src/Twig/Component/PayPalSandboxModalComponent.php
@@ -88,4 +88,9 @@ final class PayPalSandboxModalComponent
     {
         return $this->formFactory->create(PayPalSandboxCredentialsType::class);
     }
+
+    protected function getDataModelValue(): string
+    {
+        return 'norender|on(change)|*';
+    }
 }

--- a/tests/Behat/Resources/suites.yml
+++ b/tests/Behat/Resources/suites.yml
@@ -9,6 +9,7 @@ default:
                 - sylius.behat.context.hook.mailer
 
                 - sylius.behat.context.transform.address
+                - sylius.behat.context.transform.cart
                 - sylius.behat.context.transform.country
                 - sylius.behat.context.transform.channel
                 - sylius.behat.context.transform.currency


### PR DESCRIPTION
AdminBundle's modal-portal.js moves .modal elements to <body> on show.bs.modal, detaching the modal from its LiveComponent wrapper. This broke the data-action="live#action:prevent" binding, causing the sandbox credential form to fall back to a plain HTTP POST.

Fix by intercepting show.bs.modal in the capture phase (before modal-portal.js runs in the bubbling phase), moving the entire LiveComponent wrapper to <body> instead of just the modal, and restoring it to its original DOM position on hidden.bs.modal via a comment-node placeholder.

Also fix getDataModelValue() visibility (protected) and return type (string), drop Sylius ~2.0.1 from the build matrix, update the winzou_state_machine CI entry to use Sylius ~2.2.0 / Symfony ^7.4, and add a Behat scenario verifying PayPal is sorted first at checkout.

| Q               | A
| --------------- | -----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
