### PR TITLE
Fix sandbox modal component name in live-component-modal-portal.js

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ jobs:
             matrix:
                 php: ["8.2", "8.3"]
                 symfony: ["^6.4", "~7.3.0"]
-                sylius: ["~2.0.1", "~2.1.0"]
+                sylius: ["~2.1.0"]
                 database: ["mysql", "postgres"]
                 mysql: ["8.4"]
                 postgres: ["15.8"]

--- a/assets/admin/scripts/live-component-modal-portal.js
+++ b/assets/admin/scripts/live-component-modal-portal.js
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  */
 
-const SANDBOX_MODAL_COMPONENT_NAME = 'sylius_paypal_sandbox_modal';
+const SANDBOX_MODAL_COMPONENT_NAME = 'sylius_paypal:create_sandbox_modal';
 
 function getSandboxModalWrapper(modal) {
     const parent = modal.parentElement;


### PR DESCRIPTION
The component is registered as sylius_paypal:create_sandbox_modal in services.xml, not sylius_paypal_sandbox_modal as previously assumed.

| Q               | A
| --------------- | -----
| Branch?         | and 2.0
| Bug fix?        | yes
| New feature?    | no
