### PR TITLE
Complete the express checkout purchase in the PayPal wallet

### DIFF
--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -112,6 +112,13 @@
    request in an error, the payment is detached from the order, the order is reprocessed, and the buyer is
    returned to the checkout summary so the purchase can be retried.
 
+   The action also cross-references the posted `payPalOrderId` against the `paypal_order_id` the plugin itself
+   wrote onto the payment's details, and answers `422 Unprocessable Content` when the two disagree — a payment
+   carrying no `paypal_order_id` at all included. The response body is unchanged and still carries a
+   `return_url` back to the checkout summary, so the buyer is redirected as before. Nothing is fetched from
+   PayPal and nothing on the order is touched, which is what separates this from an amount mismatch: that one
+   still answers `200`, because the request *is* processed and the payment really is detached.
+
 1. #### The cart and product page button templates no longer receive `completeUrl`.
 
    `@SyliusPayPalPlugin/pay_from_cart_page.html.twig` and `@SyliusPayPalPlugin/pay_from_product_page.html.twig`

--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -79,7 +79,7 @@
    |---|---|---|
    | `CreatePayPalOrderFromCartAction` | `id`, `orderId`, `status` | `orderID` (PayPal order id) |
    | `CreatePayPalOrderFromPaymentPageAction` | `id`, `orderId`, `status` | `order_id` (PayPal order id) |
-   | `ProcessPayPalOrderAction` | `syliusOrderId`, `orderId`, `status`\* | `orderID` (**Sylius** order id) |
+   | `ProcessPayPalOrderAction` | `syliusOrderId`, `orderId`, `status`\*, plus a new `return_url` | `orderID` (**Sylius** order id) |
    | `CompletePayPalOrderFromPaymentPageAction` | `orderId`, `status` added next to `return_url` | — nothing renamed |
 
    \* `status` is the payment state, so `ProcessPayPalOrderAction` omits it in the one response it returns when
@@ -92,6 +92,40 @@
    The `orderID` returned by the deprecated `sylius_paypal_shop_create_paypal_order` route is unchanged and not
    part of this: that route serves the legacy `pay_with_paypal.html.twig` page, which still reads it.
 
+1. #### Express checkout completes the purchase in the PayPal wallet.
+
+   The PayPal buttons on the cart and product pages used to be a shortcut into the regular checkout: after the
+   buyer approved the payment in the wallet, they landed on the Sylius checkout summary and had to press
+   "Place order" a second time before anything was captured.
+
+   `Sylius\PayPalPlugin\Controller\ProcessPayPalOrderAction` (route `sylius_paypal_shop_process_paypal_order`)
+   now captures the payment and completes the order in the same request, and sends the buyer straight to the
+   thank-you page. Its JSON response carries a `return_url` next to the keys described in the entry above.
+
+   Driving the payment and the order to their completed states lives in the new
+   `Sylius\PayPalPlugin\Completer\PayPalExpressOrderCompleter` (service `sylius_paypal.completer.express_order`,
+   aliased by `Sylius\PayPalPlugin\Completer\PayPalExpressOrderCompleterInterface`), so it can be decorated or
+   replaced without touching the controller.
+
+   Two smaller changes come with it: the buyer's phone number from PayPal's `payer` payload is now written onto
+   the order's addresses and onto a newly created customer, and a payment amount mismatch no longer leaves the
+   request in an error, the payment is detached from the order, the order is reprocessed, and the buyer is
+   returned to the checkout summary so the purchase can be retried.
+
+1. #### The cart and product page button templates no longer receive `completeUrl`.
+
+   `@SyliusPayPalPlugin/pay_from_cart_page.html.twig` and `@SyliusPayPalPlugin/pay_from_product_page.html.twig`
+   redirected to a hardcoded checkout summary URL after approval. They now follow the `return_url` returned by
+   the process endpoint, the same way `pay_from_payment_page.html.twig` already did, and
+   `Sylius\PayPalPlugin\Controller\PayPalButtonsController` no longer passes the `completeUrl` variable to them.
+
+   The redirect itself now lives in the Stimulus controller these two placements render, and that controller
+   takes no `completeUrl` value. An override still reading `{{ completeUrl }}` has to be rewritten against the
+   new templates anyway, as the Web SDK v6 and Stimulus entries at the top of this file describe.
+
+   Without that the buyer is sent to the checkout summary of an order that is already completed, which is no
+   longer a cart, and with `strict_variables` enabled the template fails to render on the undefined variable.
+
 1. #### The following constructor signatures have gained new optional (nullable) arguments, following this
    package's existing deprecation pattern — not passing them is deprecated and will be required in 3.0:
 
@@ -103,3 +137,11 @@
    — unlike the other two this one has no usable fallback: the v6 placements cannot be rendered without it, so
    a controller constructed without it throws a `\RuntimeException` when a placement is rendered. If you
    instantiate or decorate this class yourself, pass `sylius_paypal.provider.paypal_web_sdk_configuration`.
+
+   `Sylius\PayPalPlugin\Controller\ProcessPayPalOrderAction`: `?UrlGeneratorInterface $router = null`,
+   `?PayPalExpressOrderCompleterInterface $orderCompleter = null`, `?OrderProcessorInterface $orderProcessor = null`
+   — these have no usable fallback either: the action throws a `\RuntimeException` when a return URL has to be
+   generated without a router, when the order has to be completed without a completer, or when a mismatched
+   payment has to be detached without an order processor. If you have redefined the
+   `sylius_paypal.controller.process_paypal_order` service with an explicit argument list, add `router`,
+   `sylius_paypal.completer.express_order` and `sylius.order_processing.order_processor` to it.

--- a/assets/shop/controllers/PaypalWebSdkController.js
+++ b/assets/shop/controllers/PaypalWebSdkController.js
@@ -14,7 +14,6 @@ export default class extends Controller {
         captureOrderUrl: String,
         cancelOrderUrl: String,
         errorUrl: String,
-        completeUrl: String,
         loadingSelector: String,
     };
 
@@ -148,7 +147,7 @@ export default class extends Controller {
             body: JSON.stringify({ payPalOrderId: data.orderId, orderId: this.syliusOrderId }),
         });
         const details = await response.json();
-        window.location.href = details.return_url || this.completeUrlValue;
+        window.location.href = details.return_url;
     }
 
     async onCancel(data) {

--- a/config/services.xml
+++ b/config/services.xml
@@ -86,6 +86,16 @@
         </service>
         <service id="Sylius\PayPalPlugin\Manager\PaymentStateManagerInterface" alias="sylius_paypal.manager.payment_state" />
 
+        <service
+            id="sylius_paypal.completer.express_order"
+            class="Sylius\PayPalPlugin\Completer\PayPalExpressOrderCompleter"
+        >
+            <argument type="service" id="sylius_paypal.manager.payment_state" />
+            <argument type="service" id="sylius_abstraction.state_machine" />
+            <argument type="service" id="sylius.manager.order" />
+        </service>
+        <service id="Sylius\PayPalPlugin\Completer\PayPalExpressOrderCompleterInterface" alias="sylius_paypal.completer.express_order" />
+
         <service id="sylius_paypal.factory.paypal_payment_method_new_resource" class="Sylius\PayPalPlugin\Factory\PayPalPaymentMethodNewResourceFactory" decorates="sylius.resource_controller.new_resource_factory">
             <argument type="service" id=".inner" />
             <argument type="service" id="sylius_paypal.onboarding.processor.basic" />

--- a/config/services/controller.xml
+++ b/config/services/controller.xml
@@ -132,6 +132,8 @@
             <argument type="service" id="sylius_paypal.api.order_details" />
             <argument type="service" id="sylius_paypal.provider.order" />
             <argument type="service" id="sylius_paypal.verifier.payment_amount" />
+            <argument type="service" id="router" />
+            <argument type="service" id="sylius_paypal.completer.express_order" />
         </service>
 
         <service id="sylius_paypal.controller.update_paypal_order" class="Sylius\PayPalPlugin\Controller\UpdatePayPalOrderAction">

--- a/config/services/controller.xml
+++ b/config/services/controller.xml
@@ -134,6 +134,7 @@
             <argument type="service" id="sylius_paypal.verifier.payment_amount" />
             <argument type="service" id="router" />
             <argument type="service" id="sylius_paypal.completer.express_order" />
+            <argument type="service" id="sylius.order_processing.order_processor" />
         </service>
 
         <service id="sylius_paypal.controller.update_paypal_order" class="Sylius\PayPalPlugin\Controller\UpdatePayPalOrderAction">

--- a/src/Completer/PayPalExpressOrderCompleter.php
+++ b/src/Completer/PayPalExpressOrderCompleter.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PayPalPlugin\Completer;
+
+use Doctrine\Persistence\ObjectManager;
+use Sylius\Abstraction\StateMachine\StateMachineInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\OrderCheckoutTransitions;
+use Sylius\PayPalPlugin\Manager\PaymentStateManagerInterface;
+
+final readonly class PayPalExpressOrderCompleter implements PayPalExpressOrderCompleterInterface
+{
+    public function __construct(
+        private PaymentStateManagerInterface $paymentStateManager,
+        private StateMachineInterface $stateMachine,
+        private ObjectManager $orderManager,
+    ) {
+    }
+
+    public function complete(OrderInterface $order, PaymentInterface $payment): void
+    {
+        $this->paymentStateManager->create($payment);
+        $this->paymentStateManager->process($payment);
+        $this->paymentStateManager->complete($payment);
+
+        $this->stateMachine->apply($order, OrderCheckoutTransitions::GRAPH, OrderCheckoutTransitions::TRANSITION_COMPLETE);
+
+        $this->orderManager->flush();
+    }
+}

--- a/src/Completer/PayPalExpressOrderCompleterInterface.php
+++ b/src/Completer/PayPalExpressOrderCompleterInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PayPalPlugin\Completer;
+
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+
+interface PayPalExpressOrderCompleterInterface
+{
+    // Callers must verify the payment amount before calling this; the correct check differs per flow.
+    public function complete(OrderInterface $order, PaymentInterface $payment): void;
+}

--- a/src/Completer/PayPalExpressOrderCompleterInterface.php
+++ b/src/Completer/PayPalExpressOrderCompleterInterface.php
@@ -18,6 +18,5 @@ use Sylius\Component\Core\Model\PaymentInterface;
 
 interface PayPalExpressOrderCompleterInterface
 {
-    // Callers must verify the payment amount before calling this; the correct check differs per flow.
     public function complete(OrderInterface $order, PaymentInterface $payment): void;
 }

--- a/src/Controller/PayPalButtonsController.php
+++ b/src/Controller/PayPalButtonsController.php
@@ -62,7 +62,6 @@ final readonly class PayPalButtonsController
                 'available_countries' => $this->availableCountriesProvider->provide(),
                 'clientId' => $this->payPalConfigurationProvider->getClientId($channel),
                 'partnerAttributionId' => $this->payPalConfigurationProvider->getPartnerAttributionId($channel),
-                'completeUrl' => $this->router->generate('sylius_shop_checkout_complete'),
                 'createPayPalOrderFromProductUrl' => $this->router->generate('sylius_paypal_shop_add_to_cart', ['productId' => $request->attributes->getInt('productId')]),
                 'errorPayPalPaymentUrl' => $this->router->generate('sylius_paypal_shop_payment_error'),
                 'locale' => $this->localeProcessor->process($this->localeContext->getLocaleCode()),
@@ -87,7 +86,6 @@ final readonly class PayPalButtonsController
             return new Response($this->twig->render('@SyliusPayPalPlugin/pay_from_cart_page.html.twig', [
                 'available_countries' => $this->availableCountriesProvider->provide(),
                 'clientId' => $this->payPalConfigurationProvider->getClientId($channel),
-                'completeUrl' => $this->router->generate('sylius_shop_checkout_complete'),
                 'createPayPalOrderFromCartUrl' => $this->router->generate('sylius_paypal_shop_create_paypal_order_from_cart', ['id' => $orderId]),
                 'currency' => $order->getCurrencyCode(),
                 'errorPayPalPaymentUrl' => $this->router->generate('sylius_paypal_shop_payment_error'),

--- a/src/Controller/ProcessPayPalOrderAction.php
+++ b/src/Controller/ProcessPayPalOrderAction.php
@@ -95,6 +95,7 @@ final readonly class ProcessPayPalOrderAction
         $purchaseUnit = (array) $data['purchase_units'][0];
 
         $address = $this->addressFactory->createNew();
+        $address->setPhoneNumber($data['payer']['phone']['phone_number']['national_number'] ?? null);
 
         if ($order->isShippingRequired()) {
             $name = explode(' ', $purchaseUnit['shipping']['name']['full_name']);
@@ -180,6 +181,7 @@ final readonly class ProcessPayPalOrderAction
         $customer->setEmail($customerData['email_address']);
         $customer->setFirstName($customerData['name']['given_name']);
         $customer->setLastName($customerData['name']['surname']);
+        $customer->setPhoneNumber($customerData['phone']['phone_number']['national_number'] ?? null);
 
         return $customer;
     }

--- a/src/Controller/ProcessPayPalOrderAction.php
+++ b/src/Controller/ProcessPayPalOrderAction.php
@@ -18,10 +18,14 @@ use Sylius\Abstraction\StateMachine\StateMachineInterface;
 use Sylius\Component\Core\Factory\AddressFactoryInterface;
 use Sylius\Component\Core\Model\AddressInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
+use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
+use Sylius\Component\Core\OrderCheckoutStates;
 use Sylius\Component\Core\OrderCheckoutTransitions;
 use Sylius\Component\Core\Repository\CustomerRepositoryInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
+use Sylius\Component\Payment\PaymentTransitions;
 use Sylius\PayPalPlugin\Api\CacheAuthorizeClientApiInterface;
 use Sylius\PayPalPlugin\Api\OrderDetailsApiInterface;
 use Sylius\PayPalPlugin\Completer\PayPalExpressOrderCompleterInterface;
@@ -55,6 +59,7 @@ final readonly class ProcessPayPalOrderAction
         private ?PaymentAmountVerifierInterface $paymentAmountVerifier = null,
         private ?UrlGeneratorInterface $router = null,
         private ?PayPalExpressOrderCompleterInterface $orderCompleter = null,
+        private ?OrderProcessorInterface $orderProcessor = null,
     ) {
         if (null === $this->paymentAmountVerifier) {
             trigger_deprecation(
@@ -82,6 +87,14 @@ final readonly class ProcessPayPalOrderAction
                 self::class,
             );
         }
+        if (null === $this->orderProcessor) {
+            trigger_deprecation(
+                'sylius/paypal-plugin',
+                '2.1',
+                'Not passing $orderProcessor to "%s" constructor is deprecated and will be prohibited in 3.0',
+                self::class,
+            );
+        }
     }
 
     public function __invoke(Request $request): Response
@@ -96,10 +109,14 @@ final readonly class ProcessPayPalOrderAction
         $payment = $order->getLastPayment(PaymentInterface::STATE_CART);
 
         if (null === $payment) {
+            $route = OrderCheckoutStates::STATE_COMPLETED === $order->getCheckoutState()
+                ? 'sylius_shop_order_thank_you'
+                : 'sylius_shop_checkout_complete';
+
             return new JsonResponse([
                 'syliusOrderId' => $orderId,
                 'orderId' => $payPalOrderId,
-                'return_url' => $this->generateReturnUrl('sylius_shop_checkout_complete'),
+                'return_url' => $this->generateReturnUrl($route),
                 'orderID' => $orderId, // BC with 2.0. Deprecated in 2.1; use "syliusOrderId" instead.
             ]);
         }
@@ -166,7 +183,7 @@ final readonly class ProcessPayPalOrderAction
                 $this->verify($payment, $data);
             }
         } catch (PaymentAmountMismatchException) {
-            $this->paymentStateManager->cancel($payment);
+            $this->abandonPayment($order, $payment);
 
             return new JsonResponse([
                 'syliusOrderId' => $orderId,
@@ -192,6 +209,22 @@ final readonly class ProcessPayPalOrderAction
             'return_url' => $this->generateReturnUrl('sylius_shop_order_thank_you'),
             'orderID' => $orderId, // BC with 2.0. Deprecated in 2.1; use "syliusOrderId" instead.
         ]);
+    }
+
+    private function abandonPayment(OrderInterface $order, PaymentInterface $payment): void
+    {
+        // The payment is still in the cart state here, where the payment state machine has no cancel transition.
+        if ($this->stateMachineFactory->can($payment, PaymentTransitions::GRAPH, PaymentTransitions::TRANSITION_CANCEL)) {
+            $this->paymentStateManager->cancel($payment);
+        }
+
+        if (null === $this->orderProcessor) {
+            throw new \RuntimeException('An order processor is required to process the order.');
+        }
+
+        $order->removePayment($payment);
+        $this->orderProcessor->process($order);
+        $this->orderManager->flush();
     }
 
     private function generateReturnUrl(string $route): string

--- a/src/Controller/ProcessPayPalOrderAction.php
+++ b/src/Controller/ProcessPayPalOrderAction.php
@@ -24,6 +24,7 @@ use Sylius\Component\Core\OrderCheckoutTransitions;
 use Sylius\Component\Core\Repository\CustomerRepositoryInterface;
 use Sylius\PayPalPlugin\Api\CacheAuthorizeClientApiInterface;
 use Sylius\PayPalPlugin\Api\OrderDetailsApiInterface;
+use Sylius\PayPalPlugin\Completer\PayPalExpressOrderCompleterInterface;
 use Sylius\PayPalPlugin\Exception\PaymentAmountMismatchException;
 use Sylius\PayPalPlugin\Manager\PaymentStateManagerInterface;
 use Sylius\PayPalPlugin\Provider\OrderProviderInterface;
@@ -32,6 +33,7 @@ use Sylius\Resource\Factory\FactoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 final readonly class ProcessPayPalOrderAction
 {
@@ -51,6 +53,8 @@ final readonly class ProcessPayPalOrderAction
         private OrderDetailsApiInterface $orderDetailsApi,
         private OrderProviderInterface $orderProvider,
         private ?PaymentAmountVerifierInterface $paymentAmountVerifier = null,
+        private ?UrlGeneratorInterface $router = null,
+        private ?PayPalExpressOrderCompleterInterface $orderCompleter = null,
     ) {
         if (null === $this->paymentAmountVerifier) {
             trigger_deprecation(
@@ -60,6 +64,22 @@ final readonly class ProcessPayPalOrderAction
                     'Not passing $paymentAmountVerifier to "%s" constructor is deprecated and will be prohibited in 3.0',
                     self::class,
                 ),
+            );
+        }
+        if (null === $this->router) {
+            trigger_deprecation(
+                'sylius/paypal-plugin',
+                '2.1',
+                'Not passing $router to "%s" constructor is deprecated and will be prohibited in 3.0',
+                self::class,
+            );
+        }
+        if (null === $this->orderCompleter) {
+            trigger_deprecation(
+                'sylius/paypal-plugin',
+                '2.1',
+                'Not passing $orderCompleter to "%s" constructor is deprecated and will be prohibited in 3.0',
+                self::class,
             );
         }
     }
@@ -79,6 +99,7 @@ final readonly class ProcessPayPalOrderAction
             return new JsonResponse([
                 'syliusOrderId' => $orderId,
                 'orderId' => $payPalOrderId,
+                'return_url' => $this->generateReturnUrl('sylius_shop_checkout_complete'),
                 'orderID' => $orderId, // BC with 2.0. Deprecated in 2.1; use "syliusOrderId" instead.
             ]);
         }
@@ -151,21 +172,35 @@ final readonly class ProcessPayPalOrderAction
                 'syliusOrderId' => $orderId,
                 'orderId' => $payPalOrderId,
                 'status' => $payment->getState(),
+                'return_url' => $this->generateReturnUrl('sylius_shop_checkout_complete'),
                 'orderID' => $orderId, // BC with 2.0. Deprecated in 2.1; use "syliusOrderId" instead.
             ]);
         }
 
-        // Deliberately no "return_url" here, unlike CompletePayPalOrderFromPaymentPageAction: this action
-        // stops at the select-payment transition and neither completes the order nor captures the PayPal
-        // payment, so the buyer has to land back on the checkout's complete step and place the order from
-        // there - which is what the placements' "completeUrl" points at. Capturing inside the wallet, and
-        // the thank-you redirect that follows from it, is https://github.com/Sylius/PayPalPlugin/pull/680.
+        if (null === $this->orderCompleter) {
+            throw new \RuntimeException('An order completer is required to complete the order.');
+        }
+
+        $this->orderCompleter->complete($order, $payment);
+
+        $request->getSession()->set('sylius_order_id', $order->getId());
+
         return new JsonResponse([
             'syliusOrderId' => $orderId,
             'orderId' => $payPalOrderId,
             'status' => $payment->getState(),
+            'return_url' => $this->generateReturnUrl('sylius_shop_order_thank_you'),
             'orderID' => $orderId, // BC with 2.0. Deprecated in 2.1; use "syliusOrderId" instead.
         ]);
+    }
+
+    private function generateReturnUrl(string $route): string
+    {
+        if (null === $this->router) {
+            throw new \RuntimeException('A router is required to generate the return URL.');
+        }
+
+        return $this->router->generate($route, [], UrlGeneratorInterface::ABSOLUTE_URL);
     }
 
     private function getOrderCustomer(array $customerData): CustomerInterface

--- a/src/Controller/ProcessPayPalOrderAction.php
+++ b/src/Controller/ProcessPayPalOrderAction.php
@@ -121,6 +121,10 @@ final readonly class ProcessPayPalOrderAction
             ]);
         }
 
+        if (($payment->getDetails()['paypal_order_id'] ?? null) !== $payPalOrderId) {
+            return $this->returnToCheckout($orderId, $payPalOrderId, $payment, Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
         $data = $this->getOrderDetails($payPalOrderId, $payment);
 
         /** @var CustomerInterface|null $customer */
@@ -185,13 +189,7 @@ final readonly class ProcessPayPalOrderAction
         } catch (PaymentAmountMismatchException) {
             $this->abandonPayment($order, $payment);
 
-            return new JsonResponse([
-                'syliusOrderId' => $orderId,
-                'orderId' => $payPalOrderId,
-                'status' => $payment->getState(),
-                'return_url' => $this->generateReturnUrl('sylius_shop_checkout_complete'),
-                'orderID' => $orderId, // BC with 2.0. Deprecated in 2.1; use "syliusOrderId" instead.
-            ]);
+            return $this->returnToCheckout($orderId, $payPalOrderId, $payment);
         }
 
         if (null === $this->orderCompleter) {
@@ -209,6 +207,21 @@ final readonly class ProcessPayPalOrderAction
             'return_url' => $this->generateReturnUrl('sylius_shop_order_thank_you'),
             'orderID' => $orderId, // BC with 2.0. Deprecated in 2.1; use "syliusOrderId" instead.
         ]);
+    }
+
+    private function returnToCheckout(
+        int $orderId,
+        string $payPalOrderId,
+        PaymentInterface $payment,
+        int $status = Response::HTTP_OK,
+    ): JsonResponse {
+        return new JsonResponse([
+            'syliusOrderId' => $orderId,
+            'orderId' => $payPalOrderId,
+            'status' => $payment->getState(),
+            'return_url' => $this->generateReturnUrl('sylius_shop_checkout_complete'),
+            'orderID' => $orderId, // BC with 2.0. Deprecated in 2.1; use "syliusOrderId" instead.
+        ], $status);
     }
 
     private function abandonPayment(OrderInterface $order, PaymentInterface $payment): void

--- a/src/Model/PayPalOrder.php
+++ b/src/Model/PayPalOrder.php
@@ -23,6 +23,8 @@ class PayPalOrder
 
     public const PAYPAL_ADDRESS = 'GET_FROM_FILE';
 
+    public const USER_ACTION_PAY_NOW = 'PAY_NOW';
+
     /** @var string */
     private $intent;
 
@@ -51,6 +53,7 @@ class PayPalOrder
             ],
             'application_context' => [
                 'shipping_preference' => $this->getShippingPreference(),
+                'user_action' => self::USER_ACTION_PAY_NOW,
             ],
         ];
     }

--- a/templates/pay_from_cart_page.html.twig
+++ b/templates/pay_from_cart_page.html.twig
@@ -9,7 +9,6 @@
         captureOrderUrl: processPayPalOrderUrl,
         cancelOrderUrl: path('sylius_paypal_shop_cancel_order'),
         errorUrl: errorPayPalPaymentUrl,
-        completeUrl: completeUrl,
         loadingSelector: '[data-live-name-value="sylius_shop:cart:form"] [data-loading]',
     }) }}
     style="margin-top: 10px"

--- a/templates/pay_from_product_page.html.twig
+++ b/templates/pay_from_product_page.html.twig
@@ -10,7 +10,6 @@
         captureOrderUrl: processPayPalOrderUrl,
         cancelOrderUrl: path('sylius_paypal_shop_cancel_order'),
         errorUrl: errorPayPalPaymentUrl,
-        completeUrl: completeUrl,
         loadingSelector: '[data-live-name-value="sylius_shop:product:add_to_cart_form"] [data-loading]',
     }) }}
 >

--- a/tests/DataFixtures/ORM/resources/new_cart.yaml
+++ b/tests/DataFixtures/ORM/resources/new_cart.yaml
@@ -28,3 +28,5 @@ Sylius\Component\Core\Model\Payment:
         currencyCode: "USD"
         amount: 40
         state: "cart"
+        details:
+            paypal_order_id: "PAYPAL_ORDER_ID"

--- a/tests/DataFixtures/ORM/resources/new_cart_without_customer.yaml
+++ b/tests/DataFixtures/ORM/resources/new_cart_without_customer.yaml
@@ -1,0 +1,29 @@
+Sylius\Component\Core\Model\Order:
+    new_cart_without_customer:
+        channel: "@channel_web"
+        items: ["@sw_mug_item_no_customer"]
+        currencyCode: "USD"
+        localeCode: "en_US"
+        state: "cart"
+        checkoutState: "cart"
+        tokenValue: "TOKEN_NO_CUSTOMER"
+        payments: ["@paypal_payment_no_customer"]
+
+Sylius\Component\Core\Model\OrderItem:
+    sw_mug_item_no_customer:
+        units: ["@sw_mug_item_unit1_no_customer", "@sw_mug_item_unit2_no_customer"]
+        variant: "@mug_sw"
+        order: "@new_cart_without_customer"
+
+Sylius\Component\Core\Model\OrderItemUnit:
+    sw_mug_item_unit1_no_customer:
+        __construct: ["@sw_mug_item_no_customer"]
+    sw_mug_item_unit2_no_customer:
+        __construct: ["@sw_mug_item_no_customer"]
+
+Sylius\Component\Core\Model\Payment:
+    paypal_payment_no_customer:
+        method: "@paypal"
+        currencyCode: "USD"
+        amount: 60
+        state: "cart"

--- a/tests/DataFixtures/ORM/resources/new_cart_without_customer.yaml
+++ b/tests/DataFixtures/ORM/resources/new_cart_without_customer.yaml
@@ -27,3 +27,5 @@ Sylius\Component\Core\Model\Payment:
         currencyCode: "USD"
         amount: 60
         state: "cart"
+        details:
+            paypal_order_id: "PAYPAL_ORDER_ID"

--- a/tests/Functional/ProcessPayPalOrderActionTest.php
+++ b/tests/Functional/ProcessPayPalOrderActionTest.php
@@ -1,0 +1,155 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\PayPalPlugin\Functional;
+
+use ApiTestCase\JsonApiTestCase;
+use Sylius\Component\Core\Model\CustomerInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\PayPalPlugin\Payum\Action\StatusAction;
+use Sylius\PayPalPlugin\Processor\PaymentCompleteProcessorInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Tests\Sylius\PayPalPlugin\Service\FakeOrderDetailsApi;
+
+final class ProcessPayPalOrderActionTest extends JsonApiTestCase
+{
+    public function test_it_completes_the_order_in_one_call_when_the_buyer_approves_in_the_wallet(): void
+    {
+        $fixtures = $this->loadFixturesFromFiles(['resources/shop.yaml', 'resources/new_cart.yaml']);
+        /** @var OrderInterface $order */
+        $order = $fixtures['new_cart'];
+
+        $this->mockOrderDetailsApi([
+            'payer' => [
+                'email_address' => 'oliver.queen@star-city.com',
+                'name' => ['given_name' => 'Oliver', 'surname' => 'Queen'],
+                'phone' => ['phone_number' => ['national_number' => '15551234567']],
+                'address' => ['country_code' => 'US'],
+            ],
+            'purchase_units' => [[
+                'amount' => ['value' => '0.60'],
+                'shipping' => [
+                    'name' => ['full_name' => 'Oliver Queen'],
+                    'address' => [
+                        'address_line_1' => '1 Star City Plaza',
+                        'admin_area_2' => 'Star City',
+                        'postal_code' => '10001',
+                        'country_code' => 'US',
+                    ],
+                ],
+            ]],
+        ]);
+        $this->mockSuccessfulPaymentCompleteProcessor();
+
+        $orderId = $order->getId();
+        $content = $this->processPayPalOrder($orderId);
+        $order = $this->refreshOrder($orderId);
+
+        $this->assertSame($orderId, $content['orderID']);
+        $this->assertSame($this->generateUrl('sylius_shop_order_thank_you'), $content['return_url']);
+        $this->assertSame('completed', $order->getCheckoutState());
+
+        /** @var PaymentInterface $payment */
+        $payment = $order->getLastPayment();
+        $this->assertSame(PaymentInterface::STATE_COMPLETED, $payment->getState());
+    }
+
+    public function test_it_creates_a_new_customer_from_the_pay_pal_payer_data_when_the_order_has_none_yet(): void
+    {
+        $fixtures = $this->loadFixturesFromFiles(['resources/shop.yaml', 'resources/new_cart_without_customer.yaml']);
+        /** @var OrderInterface $order */
+        $order = $fixtures['new_cart_without_customer'];
+
+        $this->mockOrderDetailsApi([
+            'payer' => [
+                'email_address' => 'new.buyer@example.com',
+                'name' => ['given_name' => 'Jane', 'surname' => 'Doe'],
+                'phone' => ['phone_number' => ['national_number' => '15559876543']],
+                'address' => ['country_code' => 'US'],
+            ],
+            'purchase_units' => [[
+                'amount' => ['value' => '0.60'],
+                'shipping' => [
+                    'name' => ['full_name' => 'Jane Doe'],
+                    'address' => [
+                        'address_line_1' => '42 Wallaby Way',
+                        'admin_area_2' => 'Sydney',
+                        'postal_code' => '20500',
+                        'country_code' => 'US',
+                    ],
+                ],
+            ]],
+        ]);
+        $this->mockSuccessfulPaymentCompleteProcessor();
+
+        $orderId = $order->getId();
+        $content = $this->processPayPalOrder($orderId);
+        $order = $this->refreshOrder($orderId);
+
+        $this->assertSame($this->generateUrl('sylius_shop_order_thank_you'), $content['return_url']);
+
+        /** @var CustomerInterface $customer */
+        $customer = $order->getCustomer();
+        $this->assertNotNull($customer);
+        $this->assertSame('new.buyer@example.com', $customer->getEmail());
+        $this->assertSame('15559876543', $customer->getPhoneNumber());
+    }
+
+    /** @return array<string, mixed> */
+    private function processPayPalOrder(int $orderId): array
+    {
+        $this->client->request(
+            'POST',
+            '/en_US/process-pay-pal-order/',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            (string) json_encode(['payPalOrderId' => 'PAYPAL_ORDER_ID', 'orderId' => $orderId]),
+        );
+
+        return (array) json_decode((string) $this->client->getResponse()->getContent(), true);
+    }
+
+    private function refreshOrder(int $orderId): OrderInterface
+    {
+        /** @var OrderInterface $order */
+        $order = self::getContainer()->get('sylius.repository.order')->find($orderId);
+
+        return $order;
+    }
+
+    /** @param array<string, mixed> $orderDetails */
+    private function mockOrderDetailsApi(array $orderDetails): void
+    {
+        self::getContainer()->set('sylius_paypal.api.order_details', new FakeOrderDetailsApi($orderDetails));
+    }
+
+    private function mockSuccessfulPaymentCompleteProcessor(): void
+    {
+        self::getContainer()->set('sylius_paypal.processor.payment_complete', new class() implements PaymentCompleteProcessorInterface {
+            public function completePayment(PaymentInterface $payment): void
+            {
+                $payment->setDetails(['status' => StatusAction::STATUS_COMPLETED]);
+            }
+        });
+    }
+
+    private function generateUrl(string $route): string
+    {
+        /** @var UrlGeneratorInterface $router */
+        $router = self::getContainer()->get('router');
+
+        return $router->generate($route, [], UrlGeneratorInterface::ABSOLUTE_URL);
+    }
+}

--- a/tests/Functional/ProcessPayPalOrderActionTest.php
+++ b/tests/Functional/ProcessPayPalOrderActionTest.php
@@ -106,6 +106,59 @@ final class ProcessPayPalOrderActionTest extends JsonApiTestCase
         $this->assertSame('15559876543', $customer->getPhoneNumber());
     }
 
+    public function test_it_frees_the_order_and_returns_the_buyer_to_checkout_when_the_amount_does_not_match(): void
+    {
+        $fixtures = $this->loadFixturesFromFiles(['resources/shop.yaml', 'resources/new_cart.yaml']);
+        /** @var OrderInterface $order */
+        $order = $fixtures['new_cart'];
+        /** @var PaymentInterface $originalPayment */
+        $originalPayment = $fixtures['paypal_payment'];
+        $originalPaymentId = $originalPayment->getId();
+
+        $this->mockOrderDetailsApi([
+            'payer' => [
+                'email_address' => 'oliver.queen@star-city.com',
+                'name' => ['given_name' => 'Oliver', 'surname' => 'Queen'],
+                'address' => ['country_code' => 'US'],
+            ],
+            'purchase_units' => [[
+                'amount' => ['value' => '999.00'],
+                'shipping' => [
+                    'name' => ['full_name' => 'Oliver Queen'],
+                    'address' => [
+                        'address_line_1' => '1 Star City Plaza',
+                        'admin_area_2' => 'Star City',
+                        'postal_code' => '10001',
+                        'country_code' => 'US',
+                    ],
+                ],
+            ]],
+        ]);
+
+        $orderId = $order->getId();
+        $content = $this->processPayPalOrder($orderId);
+        $order = $this->refreshOrder($orderId);
+
+        $this->assertSame($this->generateUrl('sylius_shop_checkout_complete'), $content['return_url']);
+        $this->assertNotSame('completed', $order->getCheckoutState());
+
+        /** @var PaymentInterface|null $payment */
+        $payment = $order->getLastPayment(PaymentInterface::STATE_CART);
+        $this->assertNotNull($payment);
+        $this->assertNotSame($originalPaymentId, $payment->getId());
+    }
+
+    public function test_it_returns_the_buyer_to_the_thank_you_page_when_the_order_is_already_completed(): void
+    {
+        $fixtures = $this->loadFixturesFromFiles(['resources/shop.yaml', 'resources/new_order.yaml']);
+        /** @var OrderInterface $order */
+        $order = $fixtures['new_order'];
+
+        $content = $this->processPayPalOrder($order->getId());
+
+        $this->assertSame($this->generateUrl('sylius_shop_order_thank_you'), $content['return_url']);
+    }
+
     /** @return array<string, mixed> */
     private function processPayPalOrder(int $orderId): array
     {

--- a/tests/Functional/ProcessPayPalOrderActionTest.php
+++ b/tests/Functional/ProcessPayPalOrderActionTest.php
@@ -19,6 +19,7 @@ use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\PayPalPlugin\Payum\Action\StatusAction;
 use Sylius\PayPalPlugin\Processor\PaymentCompleteProcessorInterface;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Tests\Sylius\PayPalPlugin\Service\FakeOrderDetailsApi;
 
@@ -148,6 +149,55 @@ final class ProcessPayPalOrderActionTest extends JsonApiTestCase
         $this->assertNotSame($originalPaymentId, $payment->getId());
     }
 
+    public function test_it_refuses_the_request_when_the_pay_pal_order_id_does_not_match_the_payment(): void
+    {
+        $fixtures = $this->loadFixturesFromFiles(['resources/shop.yaml', 'resources/new_cart.yaml']);
+        /** @var OrderInterface $order */
+        $order = $fixtures['new_cart'];
+        /** @var PaymentInterface $payment */
+        $payment = $fixtures['paypal_payment'];
+
+        $orderId = $order->getId();
+        $paymentId = $payment->getId();
+        $content = $this->processPayPalOrder($orderId, 'OTHER_PAYPAL_ORDER_ID');
+        $order = $this->refreshOrder($orderId);
+
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $this->client->getResponse()->getStatusCode());
+        $this->assertSame($this->generateUrl('sylius_shop_checkout_complete'), $content['return_url']);
+        $this->assertSame('shipping_selected', $order->getCheckoutState());
+        $this->assertNull($order->getShippingAddress());
+
+        /** @var PaymentInterface|null $payment */
+        $payment = $order->getLastPayment(PaymentInterface::STATE_CART);
+        $this->assertNotNull($payment);
+        $this->assertSame($paymentId, $payment->getId());
+    }
+
+    public function test_it_refuses_the_request_when_the_payment_carries_no_pay_pal_order_id(): void
+    {
+        $fixtures = $this->loadFixturesFromFiles(['resources/shop.yaml', 'resources/new_cart.yaml']);
+        /** @var OrderInterface $order */
+        $order = $fixtures['new_cart'];
+        /** @var PaymentInterface $payment */
+        $payment = $fixtures['paypal_payment'];
+
+        $orderId = $order->getId();
+        $paymentId = $payment->getId();
+        $this->clearPaymentDetails($paymentId);
+        $content = $this->processPayPalOrder($orderId);
+        $order = $this->refreshOrder($orderId);
+
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $this->client->getResponse()->getStatusCode());
+        $this->assertSame($this->generateUrl('sylius_shop_checkout_complete'), $content['return_url']);
+        $this->assertSame('shipping_selected', $order->getCheckoutState());
+        $this->assertNull($order->getShippingAddress());
+
+        /** @var PaymentInterface|null $payment */
+        $payment = $order->getLastPayment(PaymentInterface::STATE_CART);
+        $this->assertNotNull($payment);
+        $this->assertSame($paymentId, $payment->getId());
+    }
+
     public function test_it_returns_the_buyer_to_the_thank_you_page_when_the_order_is_already_completed(): void
     {
         $fixtures = $this->loadFixturesFromFiles(['resources/shop.yaml', 'resources/new_order.yaml']);
@@ -160,7 +210,7 @@ final class ProcessPayPalOrderActionTest extends JsonApiTestCase
     }
 
     /** @return array<string, mixed> */
-    private function processPayPalOrder(int $orderId): array
+    private function processPayPalOrder(int $orderId, string $payPalOrderId = 'PAYPAL_ORDER_ID'): array
     {
         $this->client->request(
             'POST',
@@ -168,10 +218,20 @@ final class ProcessPayPalOrderActionTest extends JsonApiTestCase
             [],
             [],
             ['CONTENT_TYPE' => 'application/json'],
-            (string) json_encode(['payPalOrderId' => 'PAYPAL_ORDER_ID', 'orderId' => $orderId]),
+            (string) json_encode(['payPalOrderId' => $payPalOrderId, 'orderId' => $orderId]),
         );
 
         return (array) json_decode((string) $this->client->getResponse()->getContent(), true);
+    }
+
+    private function clearPaymentDetails(int $paymentId): void
+    {
+        $manager = self::getContainer()->get('sylius.manager.payment');
+        /** @var PaymentInterface $payment */
+        $payment = self::getContainer()->get('sylius.repository.payment')->find($paymentId);
+
+        $payment->setDetails([]);
+        $manager->flush();
     }
 
     private function refreshOrder(int $orderId): OrderInterface

--- a/tests/Service/FakeOrderDetailsApi.php
+++ b/tests/Service/FakeOrderDetailsApi.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\PayPalPlugin\Service;
+
+use Sylius\PayPalPlugin\Api\OrderDetailsApiInterface;
+
+final class FakeOrderDetailsApi implements OrderDetailsApiInterface
+{
+    public function __construct(private readonly array $orderDetails)
+    {
+    }
+
+    public function get(string $token, string $orderId): array
+    {
+        return $this->orderDetails;
+    }
+}

--- a/tests/Unit/Completer/PayPalExpressOrderCompleterTest.php
+++ b/tests/Unit/Completer/PayPalExpressOrderCompleterTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\PayPalPlugin\Unit\Completer;
+
+use Doctrine\Persistence\ObjectManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Abstraction\StateMachine\StateMachineInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\OrderCheckoutTransitions;
+use Sylius\PayPalPlugin\Completer\PayPalExpressOrderCompleter;
+use Sylius\PayPalPlugin\Completer\PayPalExpressOrderCompleterInterface;
+use Sylius\PayPalPlugin\Manager\PaymentStateManagerInterface;
+
+final class PayPalExpressOrderCompleterTest extends TestCase
+{
+    private PaymentStateManagerInterface&MockObject $paymentStateManager;
+
+    private StateMachineInterface&MockObject $stateMachine;
+
+    private ObjectManager&MockObject $orderManager;
+
+    private PayPalExpressOrderCompleter $completer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->paymentStateManager = $this->createMock(PaymentStateManagerInterface::class);
+        $this->stateMachine = $this->createMock(StateMachineInterface::class);
+        $this->orderManager = $this->createMock(ObjectManager::class);
+
+        $this->completer = new PayPalExpressOrderCompleter(
+            $this->paymentStateManager,
+            $this->stateMachine,
+            $this->orderManager,
+        );
+    }
+
+    public function test_it_implements_pay_pal_express_order_completer_interface(): void
+    {
+        self::assertInstanceOf(PayPalExpressOrderCompleterInterface::class, $this->completer);
+    }
+
+    public function test_it_drives_the_payment_through_its_lifecycle_and_completes_the_order(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $payment = $this->createMock(PaymentInterface::class);
+
+        $this->paymentStateManager->expects(self::once())->method('create')->with($payment);
+        $this->paymentStateManager->expects(self::once())->method('process')->with($payment);
+        $this->paymentStateManager->expects(self::once())->method('complete')->with($payment);
+
+        $this->stateMachine
+            ->expects(self::once())
+            ->method('apply')
+            ->with($order, OrderCheckoutTransitions::GRAPH, OrderCheckoutTransitions::TRANSITION_COMPLETE)
+        ;
+
+        $this->orderManager->expects(self::once())->method('flush');
+
+        $this->completer->complete($order, $payment);
+    }
+}

--- a/tests/Unit/Model/PayPalOrderTest.php
+++ b/tests/Unit/Model/PayPalOrderTest.php
@@ -142,6 +142,7 @@ final class PayPalOrderTest extends TestCase
             ],
             'application_context' => [
                 'shipping_preference' => 'SET_PROVIDED_ADDRESS',
+                'user_action' => 'PAY_NOW',
             ],
         ], $result);
     }
@@ -227,6 +228,7 @@ final class PayPalOrderTest extends TestCase
             ],
             'application_context' => [
                 'shipping_preference' => 'GET_FROM_FILE',
+                'user_action' => 'PAY_NOW',
             ],
         ], $result);
     }
@@ -311,6 +313,7 @@ final class PayPalOrderTest extends TestCase
             ],
             'application_context' => [
                 'shipping_preference' => 'NO_SHIPPING',
+                'user_action' => 'PAY_NOW',
             ],
         ], $result);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | phase-1
| Bug fix?        | no
| New feature?    | yes
| Related tickets | 

What the plugin calls express was a shortcut into the ordinary checkout: after approving in the wallet the buyer landed on the Sylius summary page and had to press "Place order" a second time before anything was captured. PayPal recorded no express sessions at all.

The approval now captures the payment and completes the order in one request, and the buyer is returned to the thank-you page. The wallet's choices are written back to the order as before, now including the payer's phone number, and the amount is verified against the order total before the order is completed. Both placements ask PayPal for the Pay Now experience and report the page type they render on, which is how a shortcut placement is recognised.
