### PR TITLE
Show real shipping options in the PayPal shortcut

### DIFF
--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -64,12 +64,18 @@
    could not call. Decorate or replace it if your shop reaches PayPal some other way — for instance behind a
    proxy that terminates TLS in front of an `http` backend.
 
-   Two services carry the work and can be decorated or replaced:
+   Three services carry the work and can be decorated or replaced:
    `Sylius\PayPalPlugin\Resolver\PayPalShippingOptionsResolverInterface` turns an order plus a partial
-   address into PayPal's option list, and `Sylius\PayPalPlugin\Factory\PayPalShippingAddressFactoryInterface`
+   address into PayPal's option list, `Sylius\PayPalPlugin\Factory\PayPalShippingAddressFactoryInterface`
    maps PayPal's redacted address onto a Sylius one, matching the region it sends by name against your
-   provinces. Both build on stock Sylius services, so the wallet offers the same methods and prices as the
-   normal checkout does for the same address.
+   provinces, and `Sylius\PayPalPlugin\Factory\PayPalShippingCallbackResponseFactoryInterface` shapes the
+   answer. The first two build on stock Sylius services, so the wallet offers the same methods and prices as
+   the normal checkout does for the same address.
+
+   The response factory exists because PayPal validates it: the answer has to carry `amount.breakdown` with
+   `shipping` matching the option marked `selected`, and `amount.value` equal to the sum of the breakdown
+   (`item_total + tax_total + shipping + handling + insurance - discount - shipping_discount`). If you
+   decorate it, keep those two invariants or PayPal rejects the callback.
 
    The buyer's choice is written back by `Sylius\PayPalPlugin\Controller\ProcessPayPalOrderAction`, which
    now also stores the region on the order's addresses — previously it was dropped.
@@ -288,6 +294,7 @@
    | `sylius_paypal.factory.paypal_order` | `Sylius\PayPalPlugin\Factory\PayPalOrderFactoryInterface` | the whole `v2/checkout/orders` payload, including the payer return URL and the shipping callback |
    | `sylius_paypal.factory.paypal_purchase_unit` | `Sylius\PayPalPlugin\Factory\PayPalPurchaseUnitFactoryInterface` | one purchase unit, shared by order creation and the `PATCH` that updates it |
    | `sylius_paypal.provider.paypal_shipping_callback_url` | `Sylius\PayPalPlugin\Provider\PayPalShippingCallbackUrlProviderInterface` | the shipping callback URL, or `null` when PayPal could not reach it |
+   | `sylius_paypal.factory.paypal_shipping_callback_response` | `Sylius\PayPalPlugin\Factory\PayPalShippingCallbackResponseFactoryInterface` | the body the shipping callback answers with, including the total reconciled against the selected option |
 
    `PayPalPurchaseUnitFactoryInterface::create()` takes the merchant id as an optional third argument and
    falls back to the `merchant_id` configured on the payment's method, which is what every caller passed

--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -114,8 +114,31 @@
    `application_context` untouched.
 
    PayPal answers such an order with `PAYER_ACTION_REQUIRED` rather than `CREATED`, and
-   `Sylius\PayPalPlugin\Payum\Action\CaptureAction` accepts both. If you replaced that action, it must do
-   the same, or the payment will never receive its `paypal_order_id`.
+   `Sylius\PayPalPlugin\Payum\Action\CaptureAction` accepts both. Which statuses count as created comes from
+   `Sylius\PayPalPlugin\Provider\PayPalOrderCreatedStatusesProviderInterface`
+   (`sylius_paypal.provider.paypal_order_created_statuses`), so decorate that rather than the action if
+   PayPal starts answering with something else. If you replaced the action itself, it must accept both, or
+   the payment will never receive its `paypal_order_id`.
+
+   ```diff
+    final readonly class CaptureAction implements ActionInterface
+    {
+        public function __construct(
+            // ...
+   +        private ?PayPalOrderCreatedStatusesProviderInterface $orderCreatedStatusesProvider = null,
+        ) {
+        }
+   ```
+
+   ```diff
+    <service id="sylius_paypal.payum.action.capture" class="Sylius\PayPalPlugin\Payum\Action\CaptureAction" public="true">
+        <!-- ... -->
+   +    <argument type="service" id="sylius_paypal.provider.paypal_order_created_statuses" />
+    </service>
+   ```
+
+   Not passing it is deprecated and will be prohibited in 3.0; until then the action falls back to the
+   default provider, so it keeps accepting both statuses.
 
 1. #### The following routes are deprecated and will be removed in 3.0.
 

--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -48,11 +48,21 @@
    a placeholder address (`Temp`/`Temp`/`Temp`) onto the real order and sent PayPal a single, default
    shipping method. It now declares a server-side callback instead, and PayPal calls it directly.
 
-   A new route, `sylius_paypal_shop_order_shipping_callback` (`POST /pay-pal-order-shipping-callback`,
+   A new route, `sylius_paypal_order_shipping_callback` (`POST /paypal/order-shipping-callback`,
    controller `Sylius\PayPalPlugin\Controller\PayPalOrderShippingCallbackAction`), answers with every
    shipping method eligible for the address the buyer chose, each with its own price, or with a `422` naming
    the reason the order cannot be shipped there. Nothing is written to the order: the buyer has approved
    nothing yet.
+
+   It is loaded from `@SyliusPayPalPlugin/config/routes/callback.yaml`, **outside the shop's `/{_locale}`
+   prefix** — this is not a page a buyer opens but a request PayPal makes and waits on, and its URL is stored
+   with the order at PayPal for that order's lifetime. Under the locale prefix,
+   `Sylius\Bundle\ShopBundle\EventListener\NonChannelLocaleListener` answers a locale the channel no longer
+   offers with a redirect to the shop homepage, which would hand PayPal HTML where it expects JSON. The
+   path stays close to what the other PayPal integrations use for the same endpoint — WooCommerce registers
+   `paypal/v1/shipping-callback` on the REST API, Shopware `paypal/express/shipping-callback` on its
+   store-api — and keeps PayPal's own `order_update_callback_config` wording in front of it. It is a callback rather than a webhook: the refund webhook is a notification PayPal sends,
+   while this one is a synchronous call whose response drives what the wallet renders.
 
    **This endpoint has to be reachable from PayPal's servers.** It is declared on the order only when the
    generated URL is `https`, so a shop behind a tunnel or on a production domain works, and a local
@@ -81,6 +91,12 @@
    so a decorator adds or reprices an option without reproducing PayPal's payload keys. The object keeps its
    price in minor units and formats it only in `toArray()`; `TYPE_PICKUP` is there for options the buyer
    collects instead of having shipped.
+
+   Each option is labelled with the shipping method's name **in the order's locale**, read through
+   `getTranslation($order->getLocaleCode())` rather than through the locale Sylius resolves from the request.
+   That is what lets the endpoint live outside the shop's `/{_locale}` prefix: a callback PayPal makes from
+   its own network carries no buyer locale, and the order records one. A method with no translation for that
+   locale keeps the name it was loaded with.
 
    The buyer's choice is written back by `Sylius\PayPalPlugin\Controller\ProcessPayPalOrderAction`, which
    now also stores the region on the order's addresses — previously it was dropped.
@@ -114,7 +130,7 @@
    | `sylius_paypal_shop_complete_paypal_order` | `sylius_paypal_shop_process_paypal_order` / `..._complete_paypal_order_from_payment_page` |
    | `sylius_paypal_shop_cancel_checkout_payment` | `sylius_paypal_shop_cancel_payment` / `..._cancel_order` |
    | `sylius_paypal_shop_cancel_last_payment` | none — no longer needed once the legacy page is removed |
-   | `sylius_paypal_shop_update_paypal_order` | `sylius_paypal_shop_order_shipping_callback` |
+   | `sylius_paypal_shop_update_paypal_order` | `sylius_paypal_order_shipping_callback` |
 
 1. #### The create/capture-order JSON contract is now consistent across the three v6 placements.
 

--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -239,7 +239,7 @@
     {
         public function __construct(
             // ...
-   +        private ?UrlGeneratorInterface $router = null,
+   +        private ?PayPalOrderFactoryInterface $payPalOrderFactory = null,
         ) {
         }
    ```
@@ -247,9 +247,46 @@
    ```diff
     <service id="sylius_paypal.api.create_order" class="Sylius\PayPalPlugin\Api\CreateOrderApi">
         <!-- ... -->
-   +    <argument type="service" id="router" />
+   +    <argument type="service" id="sylius_paypal.factory.paypal_order" />
     </service>
    ```
 
-   Without it the order carries neither the return and cancel URLs nor the shipping callback, so the wallet
-   falls back to its plain flow with no shipping options.
+   ```diff
+    final readonly class UpdateOrderApi
+    {
+        public function __construct(
+            // ...
+   +        private ?PayPalPurchaseUnitFactoryInterface $payPalPurchaseUnitFactory = null,
+        ) {
+        }
+   ```
+
+   ```diff
+    <service id="sylius_paypal.api.update_order" class="Sylius\PayPalPlugin\Api\UpdateOrderApi">
+        <!-- ... -->
+   +    <argument type="service" id="sylius_paypal.factory.paypal_purchase_unit" />
+    </service>
+   ```
+
+   Both degrade rather than throw: without the factory each API builds the same payload it built in 2.0 from
+   the providers it already holds. For `CreateOrderApi` that means an order carrying neither the return and
+   cancel URLs nor the shipping callback, so the wallet falls back to its plain flow with no shipping options.
+
+1. #### The PayPal order payload is now assembled by factories.
+
+   `Sylius\PayPalPlugin\Api\CreateOrderApi` and `Sylius\PayPalPlugin\Api\UpdateOrderApi` no longer read the
+   order, the gateway config or the router themselves — they ask a factory for the payload and send it. Two
+   new services carry that work and can be decorated or replaced:
+
+   | Service | Interface | Builds |
+   | --- | --- | --- |
+   | `sylius_paypal.factory.paypal_order` | `Sylius\PayPalPlugin\Factory\PayPalOrderFactoryInterface` | the whole `v2/checkout/orders` payload, including the payer return URL and the shipping callback |
+   | `sylius_paypal.factory.paypal_purchase_unit` | `Sylius\PayPalPlugin\Factory\PayPalPurchaseUnitFactoryInterface` | one purchase unit, shared by order creation and the `PATCH` that updates it |
+
+   `PayPalPurchaseUnitFactoryInterface::create()` takes the merchant id as an optional third argument and
+   falls back to the `merchant_id` configured on the payment's method, which is what every caller passed
+   before. `Sylius\PayPalPlugin\Model\PayPalOrder::INTENT_CAPTURE` now holds the capture intent;
+   `CreateOrderApi::PAYPAL_INTENT_CAPTURE` is kept as an alias of it.
+
+   This is where to hook in if you need to change what reaches PayPal — overriding `CreateOrderApi` for that
+   is no longer necessary.

--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -41,19 +41,49 @@
    Then `yarn install && yarn build`. Verify by loading a product page and checking that the browser fetches
    the controller chunk and the PayPal button loses its `hidden` attribute.
 
-1. #### The shipping-address callback keeps working, under its v6 name.
+1. #### PayPal now offers the shop's real shipping methods inside the wallet.
 
-   v5's single `onShippingChange` handler is split in v6 into `onShippingAddressChange` and
-   `onShippingOptionsChange`, passed to the payment session instead of to `paypal.Buttons()`. The placements
-   register `onShippingAddressChange`, which still posts to `sylius_paypal_shop_update_paypal_order` — that
-   route is **not** deprecated and remains the mechanism that keeps the PayPal order total in line with the
-   address the buyer picks inside the wallet.
+   The cart and product ("shortcut") placements reach PayPal without a shipping address, so the buyer picks
+   one inside the wallet. Until now the plugin priced that address through a client-side handler that wrote
+   a placeholder address (`Temp`/`Temp`/`Temp`) onto the real order and sent PayPal a single, default
+   shipping method. It now declares a server-side callback instead, and PayPal calls it directly.
 
-   Only the cart and product ("shortcut") placements register it, because only they reach PayPal without a
-   shipping address. If your shop overrode either of those two templates, the override must pass the
-   controller's `updateOrderUrl` and `availableCountries` values, or the buyer's address change will no longer
-   be priced - PayPal then captures a total that no longer matches the Sylius order, and the payment is
-   rejected on return.
+   A new route, `sylius_paypal_shop_order_shipping_callback` (`POST /pay-pal-order-shipping-callback`,
+   controller `Sylius\PayPalPlugin\Controller\PayPalOrderShippingCallbackAction`), answers with every
+   shipping method eligible for the address the buyer chose, each with its own price, or with a `422` naming
+   the reason the order cannot be shipped there. Nothing is written to the order: the buyer has approved
+   nothing yet.
+
+   **This endpoint has to be reachable from PayPal's servers.** It is declared on the order only when the
+   generated URL is `https`, so a shop behind a tunnel or on a production domain works, and a local
+   development shop simply does not get wallet shipping options. Two knobs matter if the URL comes out wrong:
+   `router.request_context.host` and `router.request_context.scheme`.
+
+   Two services carry the work and can be decorated or replaced:
+   `Sylius\PayPalPlugin\Resolver\PayPalShippingOptionsResolverInterface` turns an order plus a partial
+   address into PayPal's option list, and `Sylius\PayPalPlugin\Resolver\PayPalShippingAddressResolverInterface`
+   maps PayPal's redacted address onto a Sylius one, matching the region it sends by name against your
+   provinces. Both build on stock Sylius services, so the wallet offers the same methods and prices as the
+   normal checkout does for the same address.
+
+   The buyer's choice is written back by `Sylius\PayPalPlugin\Controller\ProcessPayPalOrderAction`, which
+   now also stores the region on the order's addresses — previously it was dropped.
+
+   If your shop overrode `pay_from_cart_page.html.twig` or `pay_from_product_page.html.twig`, drop the
+   `updateOrderUrl` and `availableCountries` values from the `stimulus_controller()` call; they are no longer
+   read. Leaving them in place is harmless.
+
+1. #### Orders addressed in the PayPal wallet now name their payment source.
+
+   Cart and product placements send `payment_source.paypal.experience_context` instead of the deprecated
+   `application_context`, because PayPal reads the shipping callback configuration only from there. The two
+   are mutually exclusive — sending `shipping_preference` or `user_action` in both makes PayPal reject the
+   order — so every other flow, including the checkout payment page and the legacy card page, keeps using
+   `application_context` untouched.
+
+   PayPal answers such an order with `PAYER_ACTION_REQUIRED` rather than `CREATED`, and
+   `Sylius\PayPalPlugin\Payum\Action\CaptureAction` accepts both. If you replaced that action, it must do
+   the same, or the payment will never receive its `paypal_order_id`.
 
 1. #### The following routes are deprecated and will be removed in 3.0.
 
@@ -68,6 +98,7 @@
    | `sylius_paypal_shop_complete_paypal_order` | `sylius_paypal_shop_process_paypal_order` / `..._complete_paypal_order_from_payment_page` |
    | `sylius_paypal_shop_cancel_checkout_payment` | `sylius_paypal_shop_cancel_payment` / `..._cancel_order` |
    | `sylius_paypal_shop_cancel_last_payment` | none — no longer needed once the legacy page is removed |
+   | `sylius_paypal_shop_update_paypal_order` | `sylius_paypal_shop_order_shipping_callback` |
 
 1. #### The create/capture-order JSON contract is now consistent across the three v6 placements.
 
@@ -133,22 +164,92 @@
    Without that the buyer is sent to the checkout summary of an order that is already completed, which is no
    longer a cart, and with `strict_variables` enabled the template fails to render on the undefined variable.
 
-1. #### The following constructor signatures have gained new optional (nullable) arguments, following this
-   package's existing deprecation pattern — not passing them is deprecated and will be required in 3.0:
+1. #### The following constructor signatures have gained new optional (nullable) arguments.
 
-   `Sylius\PayPalPlugin\Controller\PayWithPayPalFormAction`: `?PayPalConfigurationProviderInterface $payPalConfigurationProvider = null`
+   Following this package's existing deprecation pattern, not passing them is deprecated and will be
+   required in 3.0. If you instantiate, decorate, or redefine any of these services with an explicit
+   argument list, add the new argument.
 
-   `Sylius\PayPalPlugin\ApiPlatform\PayPalPayment`: `?PayPalConfigurationProviderInterface $payPalConfigurationProvider = null`
+   ```diff
+    final readonly class PayWithPayPalFormAction
+    {
+        public function __construct(
+            // ...
+   +        private ?PayPalConfigurationProviderInterface $payPalConfigurationProvider = null,
+        ) {
+        }
+   ```
 
-   `Sylius\PayPalPlugin\Controller\PayPalButtonsController`: `?PayPalWebSdkConfigurationProviderInterface $webSdkConfigurationProvider = null`
-   — unlike the other two this one has no usable fallback: the v6 placements cannot be rendered without it, so
-   a controller constructed without it throws a `\RuntimeException` when a placement is rendered. If you
-   instantiate or decorate this class yourself, pass `sylius_paypal.provider.paypal_web_sdk_configuration`.
+   ```diff
+    final class PayPalPayment
+    {
+        public function __construct(
+            // ...
+   +        private ?PayPalConfigurationProviderInterface $payPalConfigurationProvider = null,
+        ) {
+        }
+   ```
 
-   `Sylius\PayPalPlugin\Controller\ProcessPayPalOrderAction`: `?UrlGeneratorInterface $router = null`,
-   `?PayPalExpressOrderCompleterInterface $orderCompleter = null`, `?OrderProcessorInterface $orderProcessor = null`
-   — these have no usable fallback either: the action throws a `\RuntimeException` when a return URL has to be
-   generated without a router, when the order has to be completed without a completer, or when a mismatched
-   payment has to be detached without an order processor. If you have redefined the
-   `sylius_paypal.controller.process_paypal_order` service with an explicit argument list, add `router`,
-   `sylius_paypal.completer.express_order` and `sylius.order_processing.order_processor` to it.
+   ```diff
+    final readonly class PayPalButtonsController
+    {
+        public function __construct(
+            // ...
+   +        private ?PayPalWebSdkConfigurationProviderInterface $webSdkConfigurationProvider = null,
+        ) {
+        }
+   ```
+
+   Unlike the two above, this one has no usable fallback: the v6 placements cannot be rendered without it,
+   so a controller constructed without it throws a `\RuntimeException` when a placement is rendered.
+
+   ```diff
+    final readonly class ProcessPayPalOrderAction
+    {
+        public function __construct(
+            // ...
+   +        private ?UrlGeneratorInterface $router = null,
+   +        private ?PayPalExpressOrderCompleterInterface $orderCompleter = null,
+   +        private ?OrderProcessorInterface $orderProcessor = null,
+   +        private ?RepositoryInterface $shippingMethodRepository = null,
+   +        private ?PayPalShippingAddressResolverInterface $shippingAddressResolver = null,
+        ) {
+        }
+   ```
+
+   ```diff
+    <service id="sylius_paypal.controller.process_paypal_order" class="Sylius\PayPalPlugin\Controller\ProcessPayPalOrderAction">
+        <!-- ... -->
+   +    <argument type="service" id="router" />
+   +    <argument type="service" id="sylius_paypal.completer.express_order" />
+   +    <argument type="service" id="sylius.order_processing.order_processor" />
+   +    <argument type="service" id="sylius.repository.shipping_method" />
+   +    <argument type="service" id="sylius_paypal.resolver.paypal_shipping_address" />
+    </service>
+   ```
+
+   The first three throw a `\RuntimeException` when they are actually needed — generating a return URL,
+   completing the order, or detaching a mismatched payment. The last two degrade instead: the action behaves
+   as it did in 2.0, which means the shipping method the buyer chose in the wallet is not applied and the
+   region is not stored. The first of those two fails the amount check and sends the buyer back to the
+   checkout instead of the thank-you page.
+
+   ```diff
+    final readonly class CreateOrderApi
+    {
+        public function __construct(
+            // ...
+   +        private ?UrlGeneratorInterface $router = null,
+        ) {
+        }
+   ```
+
+   ```diff
+    <service id="sylius_paypal.api.create_order" class="Sylius\PayPalPlugin\Api\CreateOrderApi">
+        <!-- ... -->
+   +    <argument type="service" id="router" />
+    </service>
+   ```
+
+   Without it the order carries neither the return and cancel URLs nor the shipping callback, so the wallet
+   falls back to its plain flow with no shipping options.

--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -77,10 +77,17 @@
    Three services carry the work and can be decorated or replaced:
    `Sylius\PayPalPlugin\Resolver\PayPalShippingOptionsResolverInterface` turns an order plus a partial
    address into PayPal's option list, `Sylius\PayPalPlugin\Factory\PayPalShippingAddressFactoryInterface`
-   maps PayPal's redacted address onto a Sylius one, matching the region it sends by name against your
-   provinces, and `Sylius\PayPalPlugin\Factory\PayPalShippingCallbackResponseFactoryInterface` shapes the
-   answer. The first two build on stock Sylius services, so the wallet offers the same methods and prices as
-   the normal checkout does for the same address.
+   maps PayPal's redacted address onto a Sylius one, and
+   `Sylius\PayPalPlugin\Factory\PayPalShippingCallbackResponseFactoryInterface` shapes the answer. The first
+   two build on stock Sylius services, so the wallet offers the same methods and prices as the normal
+   checkout does for the same address.
+
+   The region is matched **by code, not by name**. PayPal sends it in `admin_area_1`, which is a state or
+   province code for the countries it tabulates and the spelling of the region's name for the rest. Sylius
+   validates province codes as `XX-YYY` (`/^[A-Z]{2}-[A-Z0-9]{1,}$/`, e.g. `US-FL`), so the factory looks up
+   `"{country_code}-{admin_area_1}"` first, then bare `admin_area_1` for shops whose codes bypassed that
+   validation. When neither resolves, the value is stored as the address's province *name* instead, so an
+   unrecognised region is kept rather than dropped and does not block the order.
 
    The response factory exists because PayPal validates it: the answer has to carry `amount.breakdown` with
    `shipping` matching the option marked `selected`, and `amount.value` equal to the sum of the breakdown

--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -77,6 +77,11 @@
    (`item_total + tax_total + shipping + handling + insurance - discount - shipping_discount`). If you
    decorate it, keep those two invariants or PayPal rejects the callback.
 
+   The options resolver returns `Sylius\PayPalPlugin\Model\PayPalShippingOption` objects rather than arrays,
+   so a decorator adds or reprices an option without reproducing PayPal's payload keys. The object keeps its
+   price in minor units and formats it only in `toArray()`; `TYPE_PICKUP` is there for options the buyer
+   collects instead of having shipped.
+
    The buyer's choice is written back by `Sylius\PayPalPlugin\Controller\ProcessPayPalOrderAction`, which
    now also stores the region on the order's addresses — previously it was dropped.
 

--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -59,6 +59,11 @@
    development shop simply does not get wallet shipping options. Two knobs matter if the URL comes out wrong:
    `router.request_context.host` and `router.request_context.scheme`.
 
+   That rule lives in `Sylius\PayPalPlugin\Provider\PayPalShippingCallbackUrlProviderInterface`
+   (`sylius_paypal.provider.paypal_shipping_callback_url`), which returns `null` rather than a URL PayPal
+   could not call. Decorate or replace it if your shop reaches PayPal some other way — for instance behind a
+   proxy that terminates TLS in front of an `http` backend.
+
    Two services carry the work and can be decorated or replaced:
    `Sylius\PayPalPlugin\Resolver\PayPalShippingOptionsResolverInterface` turns an order plus a partial
    address into PayPal's option list, and `Sylius\PayPalPlugin\Factory\PayPalShippingAddressFactoryInterface`
@@ -282,6 +287,7 @@
    | --- | --- | --- |
    | `sylius_paypal.factory.paypal_order` | `Sylius\PayPalPlugin\Factory\PayPalOrderFactoryInterface` | the whole `v2/checkout/orders` payload, including the payer return URL and the shipping callback |
    | `sylius_paypal.factory.paypal_purchase_unit` | `Sylius\PayPalPlugin\Factory\PayPalPurchaseUnitFactoryInterface` | one purchase unit, shared by order creation and the `PATCH` that updates it |
+   | `sylius_paypal.provider.paypal_shipping_callback_url` | `Sylius\PayPalPlugin\Provider\PayPalShippingCallbackUrlProviderInterface` | the shipping callback URL, or `null` when PayPal could not reach it |
 
    `PayPalPurchaseUnitFactoryInterface::create()` takes the merchant id as an optional third argument and
    falls back to the `merchant_id` configured on the payment's method, which is what every caller passed

--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -61,7 +61,7 @@
 
    Two services carry the work and can be decorated or replaced:
    `Sylius\PayPalPlugin\Resolver\PayPalShippingOptionsResolverInterface` turns an order plus a partial
-   address into PayPal's option list, and `Sylius\PayPalPlugin\Resolver\PayPalShippingAddressResolverInterface`
+   address into PayPal's option list, and `Sylius\PayPalPlugin\Factory\PayPalShippingAddressFactoryInterface`
    maps PayPal's redacted address onto a Sylius one, matching the region it sends by name against your
    provinces. Both build on stock Sylius services, so the wallet offers the same methods and prices as the
    normal checkout does for the same address.
@@ -212,7 +212,7 @@
    +        private ?PayPalExpressOrderCompleterInterface $orderCompleter = null,
    +        private ?OrderProcessorInterface $orderProcessor = null,
    +        private ?RepositoryInterface $shippingMethodRepository = null,
-   +        private ?PayPalShippingAddressResolverInterface $shippingAddressResolver = null,
+   +        private ?PayPalShippingAddressFactoryInterface $shippingAddressFactory = null,
         ) {
         }
    ```
@@ -224,7 +224,7 @@
    +    <argument type="service" id="sylius_paypal.completer.express_order" />
    +    <argument type="service" id="sylius.order_processing.order_processor" />
    +    <argument type="service" id="sylius.repository.shipping_method" />
-   +    <argument type="service" id="sylius_paypal.resolver.paypal_shipping_address" />
+   +    <argument type="service" id="sylius_paypal.factory.paypal_shipping_address" />
     </service>
    ```
 

--- a/assets/shop/controllers/PaypalWebSdkController.js
+++ b/assets/shop/controllers/PaypalWebSdkController.js
@@ -8,8 +8,6 @@ export default class extends Controller {
         instanceConfig: Object,
         currencyCode: String,
         createOrderUrl: String,
-        updateOrderUrl: String,
-        availableCountries: Array,
         addToCartFormSelector: String,
         captureOrderUrl: String,
         cancelOrderUrl: String,
@@ -39,17 +37,11 @@ export default class extends Controller {
                 return;
             }
 
-            const sessionOptions = {
+            const paymentSession = sdkInstance.createPayPalOneTimePaymentSession({
                 onApprove: this.onApprove.bind(this),
                 onCancel: this.onCancel.bind(this),
                 onError: this.onError.bind(this),
-            };
-
-            if (this.hasUpdateOrderUrlValue && this.updateOrderUrlValue !== '') {
-                sessionOptions.onShippingAddressChange = this.onShippingAddressChange.bind(this);
-            }
-
-            const paymentSession = sdkInstance.createPayPalOneTimePaymentSession(sessionOptions);
+            });
 
             this.paypalButtonTarget.removeAttribute('hidden');
             this.paypalButtonTarget.addEventListener('click', async () => {
@@ -105,39 +97,6 @@ export default class extends Controller {
         this.syliusOrderId = data.id;
 
         return { orderId: data.orderId };
-    }
-
-    /**
-     * The v6 counterpart of the v5 buttons' onShippingChange: PayPal calls it in the browser whenever
-     * the buyer picks or changes their shipping address inside the wallet, and the order total has to be
-     * brought in line with that address before they approve - otherwise the amount PayPal captures no
-     * longer matches the Sylius order, and ProcessPayPalOrderAction rejects the payment. Throwing makes
-     * PayPal reject the address and ask the buyer for another one.
-     */
-    async onShippingAddressChange(data) {
-        const shippingAddress = data.shippingAddress ?? {};
-
-        if (!this.availableCountriesValue.includes(shippingAddress.countryCode)) {
-            throw new Error(data.errors.COUNTRY_ERROR);
-        }
-
-        const response = await fetch(this.updateOrderUrlValue, {
-            method: 'post',
-            headers: { 'content-type': 'application/json' },
-            body: JSON.stringify({
-                orderID: data.orderId,
-                shipping_address: {
-                    city: shippingAddress.city,
-                    state: shippingAddress.state,
-                    postal_code: shippingAddress.postalCode,
-                    country_code: shippingAddress.countryCode,
-                },
-            }),
-        });
-
-        if (!response.ok) {
-            throw new Error(data.errors.ADDRESS_ERROR);
-        }
     }
 
     async onApprove(data) {

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -10,3 +10,6 @@ sylius_paypal_shop:
 
 sylius_paypal_webhook:
     resource: "@SyliusPayPalPlugin/config/routes/webhook.yaml"
+
+sylius_paypal_callback:
+    resource: "@SyliusPayPalPlugin/config/routes/callback.yaml"

--- a/config/routes/callback.yaml
+++ b/config/routes/callback.yaml
@@ -1,0 +1,5 @@
+sylius_paypal_order_shipping_callback:
+    path: /paypal/order-shipping-callback
+    methods: [POST]
+    defaults:
+        _controller: sylius_paypal.controller.paypal_order_shipping_callback

--- a/config/routes/shop.yaml
+++ b/config/routes/shop.yaml
@@ -34,6 +34,12 @@ sylius_paypal_shop_update_paypal_order:
     defaults:
         _controller: sylius_paypal.controller.update_paypal_order
 
+sylius_paypal_shop_order_shipping_callback:
+    path: /pay-pal-order-shipping-callback
+    methods: [POST]
+    defaults:
+        _controller: sylius_paypal.controller.paypal_order_shipping_callback
+
 sylius_paypal_shop_create_paypal_order_from_payment_page:
     path: /pay-pal-order-payment-page/{id}/create
     methods: [POST]

--- a/config/routes/shop.yaml
+++ b/config/routes/shop.yaml
@@ -34,12 +34,6 @@ sylius_paypal_shop_update_paypal_order:
     defaults:
         _controller: sylius_paypal.controller.update_paypal_order
 
-sylius_paypal_shop_order_shipping_callback:
-    path: /pay-pal-order-shipping-callback
-    methods: [POST]
-    defaults:
-        _controller: sylius_paypal.controller.paypal_order_shipping_callback
-
 sylius_paypal_shop_create_paypal_order_from_payment_page:
     path: /pay-pal-order-payment-page/{id}/create
     methods: [POST]

--- a/config/services.xml
+++ b/config/services.xml
@@ -101,6 +101,15 @@
             <argument type="service" id="sylius_paypal.onboarding.processor.basic" />
         </service>
 
+        <service
+            id="sylius_paypal.factory.paypal_shipping_address"
+            class="Sylius\PayPalPlugin\Factory\PayPalShippingAddressFactory"
+        >
+            <argument type="service" id="sylius.factory.address" />
+            <argument type="service" id="sylius.repository.province" />
+        </service>
+        <service id="Sylius\PayPalPlugin\Factory\PayPalShippingAddressFactoryInterface" alias="sylius_paypal.factory.paypal_shipping_address" />
+
         <service id="sylius_paypal.provider.order" class="Sylius\PayPalPlugin\Provider\OrderProvider">
             <argument type="service" id="sylius.repository.order" />
         </service>
@@ -391,15 +400,6 @@
             <argument>%sylius_paypal.supported_locales%</argument>
         </service>
         <service id="Sylius\PayPalPlugin\Resolver\SupportedLocaleResolverInterface" alias="sylius_paypal.resolver.supported_locale" />
-
-        <service
-            id="sylius_paypal.resolver.paypal_shipping_address"
-            class="Sylius\PayPalPlugin\Resolver\PayPalShippingAddressResolver"
-        >
-            <argument type="service" id="sylius.factory.address" />
-            <argument type="service" id="sylius.repository.province" />
-        </service>
-        <service id="Sylius\PayPalPlugin\Resolver\PayPalShippingAddressResolverInterface" alias="sylius_paypal.resolver.paypal_shipping_address" />
 
         <service
             id="sylius_paypal.resolver.paypal_shipping_options"

--- a/config/services.xml
+++ b/config/services.xml
@@ -149,6 +149,12 @@
         <service id="Sylius\PayPalPlugin\Provider\PayPalShippingCallbackUrlProviderInterface" alias="sylius_paypal.provider.paypal_shipping_callback_url" />
 
         <service
+            id="sylius_paypal.provider.paypal_order_created_statuses"
+            class="Sylius\PayPalPlugin\Provider\PayPalOrderCreatedStatusesProvider"
+        />
+        <service id="Sylius\PayPalPlugin\Provider\PayPalOrderCreatedStatusesProviderInterface" alias="sylius_paypal.provider.paypal_order_created_statuses" />
+
+        <service
             id="sylius_paypal.provider.payment"
             class="Sylius\PayPalPlugin\Provider\PaymentProvider"
         >

--- a/config/services.xml
+++ b/config/services.xml
@@ -129,6 +129,12 @@
         </service>
         <service id="Sylius\PayPalPlugin\Factory\PayPalOrderFactoryInterface" alias="sylius_paypal.factory.paypal_order" />
 
+        <service
+            id="sylius_paypal.factory.paypal_shipping_callback_response"
+            class="Sylius\PayPalPlugin\Factory\PayPalShippingCallbackResponseFactory"
+        />
+        <service id="Sylius\PayPalPlugin\Factory\PayPalShippingCallbackResponseFactoryInterface" alias="sylius_paypal.factory.paypal_shipping_callback_response" />
+
         <service id="sylius_paypal.provider.order" class="Sylius\PayPalPlugin\Provider\OrderProvider">
             <argument type="service" id="sylius.repository.order" />
         </service>

--- a/config/services.xml
+++ b/config/services.xml
@@ -390,5 +390,23 @@
             <argument>%sylius_paypal.supported_locales%</argument>
         </service>
         <service id="Sylius\PayPalPlugin\Resolver\SupportedLocaleResolverInterface" alias="sylius_paypal.resolver.supported_locale" />
+
+        <service
+            id="sylius_paypal.resolver.paypal_shipping_address"
+            class="Sylius\PayPalPlugin\Resolver\PayPalShippingAddressResolver"
+        >
+            <argument type="service" id="sylius.factory.address" />
+            <argument type="service" id="sylius.repository.province" />
+        </service>
+        <service id="Sylius\PayPalPlugin\Resolver\PayPalShippingAddressResolverInterface" alias="sylius_paypal.resolver.paypal_shipping_address" />
+
+        <service
+            id="sylius_paypal.resolver.paypal_shipping_options"
+            class="Sylius\PayPalPlugin\Resolver\PayPalShippingOptionsResolver"
+        >
+            <argument type="service" id="sylius.resolver.shipping_methods" />
+            <argument type="service" id="sylius.calculator.shipping" />
+        </service>
+        <service id="Sylius\PayPalPlugin\Resolver\PayPalShippingOptionsResolverInterface" alias="sylius_paypal.resolver.paypal_shipping_options" />
     </services>
 </container>

--- a/config/services.xml
+++ b/config/services.xml
@@ -110,6 +110,24 @@
         </service>
         <service id="Sylius\PayPalPlugin\Factory\PayPalShippingAddressFactoryInterface" alias="sylius_paypal.factory.paypal_shipping_address" />
 
+        <service
+            id="sylius_paypal.factory.paypal_purchase_unit"
+            class="Sylius\PayPalPlugin\Factory\PayPalPurchaseUnitFactory"
+        >
+            <argument type="service" id="sylius_paypal.provider.payment_reference_number" />
+            <argument type="service" id="sylius_paypal.provider.paypal_item_data" />
+        </service>
+        <service id="Sylius\PayPalPlugin\Factory\PayPalPurchaseUnitFactoryInterface" alias="sylius_paypal.factory.paypal_purchase_unit" />
+
+        <service
+            id="sylius_paypal.factory.paypal_order"
+            class="Sylius\PayPalPlugin\Factory\PayPalOrderFactory"
+        >
+            <argument type="service" id="sylius_paypal.factory.paypal_purchase_unit" />
+            <argument type="service" id="router" />
+        </service>
+        <service id="Sylius\PayPalPlugin\Factory\PayPalOrderFactoryInterface" alias="sylius_paypal.factory.paypal_order" />
+
         <service id="sylius_paypal.provider.order" class="Sylius\PayPalPlugin\Provider\OrderProvider">
             <argument type="service" id="sylius.repository.order" />
         </service>

--- a/config/services.xml
+++ b/config/services.xml
@@ -125,6 +125,7 @@
         >
             <argument type="service" id="sylius_paypal.factory.paypal_purchase_unit" />
             <argument type="service" id="router" />
+            <argument type="service" id="sylius_paypal.provider.paypal_shipping_callback_url" />
         </service>
         <service id="Sylius\PayPalPlugin\Factory\PayPalOrderFactoryInterface" alias="sylius_paypal.factory.paypal_order" />
 
@@ -132,6 +133,14 @@
             <argument type="service" id="sylius.repository.order" />
         </service>
         <service id="Sylius\PayPalPlugin\Provider\OrderProviderInterface" alias="sylius_paypal.provider.order" />
+
+        <service
+            id="sylius_paypal.provider.paypal_shipping_callback_url"
+            class="Sylius\PayPalPlugin\Provider\PayPalShippingCallbackUrlProvider"
+        >
+            <argument type="service" id="router" />
+        </service>
+        <service id="Sylius\PayPalPlugin\Provider\PayPalShippingCallbackUrlProviderInterface" alias="sylius_paypal.provider.paypal_shipping_callback_url" />
 
         <service
             id="sylius_paypal.provider.payment"

--- a/config/services.xml
+++ b/config/services.xml
@@ -156,6 +156,7 @@
             <argument type="service" id="sylius.context.channel" />
         </service>
         <service id="Sylius\PayPalPlugin\Provider\AvailableCountriesProviderInterface" alias="sylius_paypal.provider.available_countries" />
+        <service id="Sylius\PayPalPlugin\Provider\ChannelAvailableCountriesProviderInterface" alias="sylius_paypal.provider.available_countries" />
 
         <service id="sylius_paypal.resolver.capture_payment" class="Sylius\PayPalPlugin\Resolver\CapturePaymentResolver">
             <argument type="service" id="payum" />

--- a/config/services/api.xml
+++ b/config/services/api.xml
@@ -90,7 +90,7 @@
             <argument type="service" id="sylius_paypal.client.paypal" />
             <argument type="service" id="sylius_paypal.provider.payment_reference_number" />
             <argument type="service" id="sylius_paypal.provider.paypal_item_data" />
-            <argument type="service" id="router" />
+            <argument type="service" id="sylius_paypal.factory.paypal_order" />
         </service>
         <service id="Sylius\PayPalPlugin\Api\CreateOrderApiInterface" alias="sylius_paypal.api.create_order" />
 
@@ -162,6 +162,7 @@
             <argument type="service" id="sylius_paypal.client.paypal" />
             <argument type="service" id="sylius_paypal.provider.payment_reference_number" />
             <argument type="service" id="sylius_paypal.provider.paypal_item_data" />
+            <argument type="service" id="sylius_paypal.factory.paypal_purchase_unit" />
         </service>
         <service id="Sylius\PayPalPlugin\Api\UpdateOrderApiInterface" alias="sylius_paypal.api.update_order" />
 

--- a/config/services/api.xml
+++ b/config/services/api.xml
@@ -90,6 +90,7 @@
             <argument type="service" id="sylius_paypal.client.paypal" />
             <argument type="service" id="sylius_paypal.provider.payment_reference_number" />
             <argument type="service" id="sylius_paypal.provider.paypal_item_data" />
+            <argument type="service" id="router" />
         </service>
         <service id="Sylius\PayPalPlugin\Api\CreateOrderApiInterface" alias="sylius_paypal.api.create_order" />
 

--- a/config/services/controller.xml
+++ b/config/services/controller.xml
@@ -135,6 +135,7 @@
             <argument type="service" id="router" />
             <argument type="service" id="sylius_paypal.completer.express_order" />
             <argument type="service" id="sylius.order_processing.order_processor" />
+            <argument type="service" id="sylius.repository.shipping_method" />
         </service>
 
         <service id="sylius_paypal.controller.update_paypal_order" class="Sylius\PayPalPlugin\Controller\UpdatePayPalOrderAction">

--- a/config/services/controller.xml
+++ b/config/services/controller.xml
@@ -136,6 +136,7 @@
             <argument type="service" id="sylius_paypal.completer.express_order" />
             <argument type="service" id="sylius.order_processing.order_processor" />
             <argument type="service" id="sylius.repository.shipping_method" />
+            <argument type="service" id="sylius_paypal.resolver.paypal_shipping_address" />
         </service>
 
         <service id="sylius_paypal.controller.update_paypal_order" class="Sylius\PayPalPlugin\Controller\UpdatePayPalOrderAction">

--- a/config/services/controller.xml
+++ b/config/services/controller.xml
@@ -153,6 +153,7 @@
             <argument type="service" id="sylius_paypal.provider.available_countries" />
             <argument type="service" id="sylius_paypal.factory.paypal_shipping_address" />
             <argument type="service" id="sylius_paypal.resolver.paypal_shipping_options" />
+            <argument type="service" id="sylius_paypal.factory.paypal_shipping_callback_response" />
         </service>
 
         <service id="sylius_paypal.controller.complete_paypal_order_from_payment_page" class="Sylius\PayPalPlugin\Controller\CompletePayPalOrderFromPaymentPageAction">

--- a/config/services/controller.xml
+++ b/config/services/controller.xml
@@ -136,7 +136,7 @@
             <argument type="service" id="sylius_paypal.completer.express_order" />
             <argument type="service" id="sylius.order_processing.order_processor" />
             <argument type="service" id="sylius.repository.shipping_method" />
-            <argument type="service" id="sylius_paypal.resolver.paypal_shipping_address" />
+            <argument type="service" id="sylius_paypal.factory.paypal_shipping_address" />
         </service>
 
         <service id="sylius_paypal.controller.update_paypal_order" class="Sylius\PayPalPlugin\Controller\UpdatePayPalOrderAction">
@@ -151,7 +151,7 @@
         <service id="sylius_paypal.controller.paypal_order_shipping_callback" class="Sylius\PayPalPlugin\Controller\PayPalOrderShippingCallbackAction">
             <argument type="service" id="sylius_paypal.repository.query.paypal_payment" />
             <argument type="service" id="sylius_paypal.provider.available_countries" />
-            <argument type="service" id="sylius_paypal.resolver.paypal_shipping_address" />
+            <argument type="service" id="sylius_paypal.factory.paypal_shipping_address" />
             <argument type="service" id="sylius_paypal.resolver.paypal_shipping_options" />
         </service>
 

--- a/config/services/controller.xml
+++ b/config/services/controller.xml
@@ -146,6 +146,13 @@
             <argument type="service" id="sylius_paypal.repository.query.paypal_payment" />
         </service>
 
+        <service id="sylius_paypal.controller.paypal_order_shipping_callback" class="Sylius\PayPalPlugin\Controller\PayPalOrderShippingCallbackAction">
+            <argument type="service" id="sylius_paypal.repository.query.paypal_payment" />
+            <argument type="service" id="sylius_paypal.provider.available_countries" />
+            <argument type="service" id="sylius_paypal.resolver.paypal_shipping_address" />
+            <argument type="service" id="sylius_paypal.resolver.paypal_shipping_options" />
+        </service>
+
         <service id="sylius_paypal.controller.complete_paypal_order_from_payment_page" class="Sylius\PayPalPlugin\Controller\CompletePayPalOrderFromPaymentPageAction">
             <argument type="service" id="sylius_paypal.manager.payment_state" />
             <argument type="service" id="router" />

--- a/config/services/payum.xml
+++ b/config/services/payum.xml
@@ -33,6 +33,7 @@
             <argument type="service" id="sylius_paypal.api.cache_authorize_client" />
             <argument type="service" id="sylius_paypal.api.create_order" />
             <argument type="service" id="sylius_paypal.provider.uuid" />
+            <argument type="service" id="sylius_paypal.provider.paypal_order_created_statuses" />
             <tag name="payum.action" factory="sylius_paypal" alias="payum.action.capture" />
         </service>
 

--- a/src/Api/CreateOrderApi.php
+++ b/src/Api/CreateOrderApi.php
@@ -13,34 +13,30 @@ declare(strict_types=1);
 
 namespace Sylius\PayPalPlugin\Api;
 
-use Sylius\Bundle\PayumBundle\Model\GatewayConfigInterface;
-use Sylius\Component\Core\Model\AdjustmentInterface;
-use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
-use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\PayPalPlugin\Client\PayPalClientInterface;
+use Sylius\PayPalPlugin\Factory\PayPalOrderFactory;
+use Sylius\PayPalPlugin\Factory\PayPalOrderFactoryInterface;
+use Sylius\PayPalPlugin\Factory\PayPalPurchaseUnitFactory;
 use Sylius\PayPalPlugin\Model\PayPalOrder;
-use Sylius\PayPalPlugin\Model\PayPalPurchaseUnit;
 use Sylius\PayPalPlugin\Provider\PaymentReferenceNumberProviderInterface;
 use Sylius\PayPalPlugin\Provider\PayPalItemDataProviderInterface;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Webmozart\Assert\Assert;
 
 final readonly class CreateOrderApi implements CreateOrderApiInterface
 {
-    public const PAYPAL_INTENT_CAPTURE = 'CAPTURE';
+    public const PAYPAL_INTENT_CAPTURE = PayPalOrder::INTENT_CAPTURE;
 
     public function __construct(
         private PayPalClientInterface $client,
         private PaymentReferenceNumberProviderInterface $paymentReferenceNumberProvider,
         private PayPalItemDataProviderInterface $payPalItemDataProvider,
-        private ?UrlGeneratorInterface $router = null,
+        private ?PayPalOrderFactoryInterface $payPalOrderFactory = null,
     ) {
-        if (null === $this->router) {
+        if (null === $this->payPalOrderFactory) {
             trigger_deprecation(
                 'sylius/paypal-plugin',
                 '2.1',
-                'Not passing $router to "%s" constructor is deprecated and will be prohibited in 3.0',
+                'Not passing $payPalOrderFactory to "%s" constructor is deprecated and will be prohibited in 3.0',
                 self::class,
             );
         }
@@ -48,72 +44,18 @@ final readonly class CreateOrderApi implements CreateOrderApiInterface
 
     public function create(string $token, PaymentInterface $payment, string $referenceId): array
     {
-        /** @var OrderInterface $order */
-        $order = $payment->getOrder();
-
-        /** @var PaymentMethodInterface $paymentMethod */
-        $paymentMethod = $payment->getMethod();
-
-        /** @var GatewayConfigInterface $gatewayConfig */
-        $gatewayConfig = $paymentMethod->getGatewayConfig();
-
-        $payPalItemData = $this->payPalItemDataProvider->provide($order);
-
-        $config = $gatewayConfig->getConfig();
-
-        Assert::keyExists($config, 'merchant_id');
-        Assert::keyExists($config, 'sylius_merchant_id');
-
-        $shippingDiscount = $order->getAdjustmentsTotalRecursively(
-            AdjustmentInterface::ORDER_SHIPPING_PROMOTION_ADJUSTMENT,
-        );
-
-        $payPalPurchaseUnit = new PayPalPurchaseUnit(
-            $referenceId,
-            $this->paymentReferenceNumberProvider->provide($payment),
-            (string) $order->getCurrencyCode(),
-            (int) $payment->getAmount(),
-            $order->getShippingTotal() - $shippingDiscount,
-            (float) $payPalItemData['total_item_value'],
-            (float) $payPalItemData['total_tax'],
-            $order->getOrderPromotionTotal(),
-            (string) $config['merchant_id'],
-            (array) $payPalItemData['items'],
-            $order->isShippingRequired(),
-            $order->getShippingAddress(),
-            shippingDiscountValue: $shippingDiscount,
-        );
-
-        $payerReturnUrl = $this->router?->generate(
-            'sylius_shop_checkout_complete',
-            [],
-            UrlGeneratorInterface::ABSOLUTE_URL,
-        );
-
-        $payPalOrder = new PayPalOrder(
-            $order,
-            $payPalPurchaseUnit,
-            self::PAYPAL_INTENT_CAPTURE,
-            $payerReturnUrl,
-            $payerReturnUrl,
-            $this->getShippingCallbackUrl(),
-        );
+        $payPalOrder = $this->getPayPalOrderFactory()->create($payment, $referenceId);
 
         return $this->client->post('v2/checkout/orders', $token, $payPalOrder->toArray());
     }
 
-    private function getShippingCallbackUrl(): ?string
+    private function getPayPalOrderFactory(): PayPalOrderFactoryInterface
     {
-        $callbackUrl = $this->router?->generate(
-            'sylius_paypal_shop_order_shipping_callback',
-            [],
-            UrlGeneratorInterface::ABSOLUTE_URL,
+        return $this->payPalOrderFactory ?? new PayPalOrderFactory(
+            new PayPalPurchaseUnitFactory(
+                $this->paymentReferenceNumberProvider,
+                $this->payPalItemDataProvider,
+            ),
         );
-
-        if (null === $callbackUrl || !str_starts_with($callbackUrl, 'https://')) {
-            return null;
-        }
-
-        return $callbackUrl;
     }
 }

--- a/src/Api/CreateOrderApi.php
+++ b/src/Api/CreateOrderApi.php
@@ -23,6 +23,7 @@ use Sylius\PayPalPlugin\Model\PayPalOrder;
 use Sylius\PayPalPlugin\Model\PayPalPurchaseUnit;
 use Sylius\PayPalPlugin\Provider\PaymentReferenceNumberProviderInterface;
 use Sylius\PayPalPlugin\Provider\PayPalItemDataProviderInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Webmozart\Assert\Assert;
 
 final readonly class CreateOrderApi implements CreateOrderApiInterface
@@ -33,7 +34,16 @@ final readonly class CreateOrderApi implements CreateOrderApiInterface
         private PayPalClientInterface $client,
         private PaymentReferenceNumberProviderInterface $paymentReferenceNumberProvider,
         private PayPalItemDataProviderInterface $payPalItemDataProvider,
+        private ?UrlGeneratorInterface $router = null,
     ) {
+        if (null === $this->router) {
+            trigger_deprecation(
+                'sylius/paypal-plugin',
+                '2.1',
+                'Not passing $router to "%s" constructor is deprecated and will be prohibited in 3.0',
+                self::class,
+            );
+        }
     }
 
     public function create(string $token, PaymentInterface $payment, string $referenceId): array
@@ -74,7 +84,19 @@ final readonly class CreateOrderApi implements CreateOrderApiInterface
             shippingDiscountValue: $shippingDiscount,
         );
 
-        $payPalOrder = new PayPalOrder($order, $payPalPurchaseUnit, self::PAYPAL_INTENT_CAPTURE);
+        $payerReturnUrl = $this->router?->generate(
+            'sylius_shop_checkout_complete',
+            [],
+            UrlGeneratorInterface::ABSOLUTE_URL,
+        );
+
+        $payPalOrder = new PayPalOrder(
+            $order,
+            $payPalPurchaseUnit,
+            self::PAYPAL_INTENT_CAPTURE,
+            $payerReturnUrl,
+            $payerReturnUrl,
+        );
 
         return $this->client->post('v2/checkout/orders', $token, $payPalOrder->toArray());
     }

--- a/src/Api/CreateOrderApi.php
+++ b/src/Api/CreateOrderApi.php
@@ -96,8 +96,24 @@ final readonly class CreateOrderApi implements CreateOrderApiInterface
             self::PAYPAL_INTENT_CAPTURE,
             $payerReturnUrl,
             $payerReturnUrl,
+            $this->getShippingCallbackUrl(),
         );
 
         return $this->client->post('v2/checkout/orders', $token, $payPalOrder->toArray());
+    }
+
+    private function getShippingCallbackUrl(): ?string
+    {
+        $callbackUrl = $this->router?->generate(
+            'sylius_paypal_shop_order_shipping_callback',
+            [],
+            UrlGeneratorInterface::ABSOLUTE_URL,
+        );
+
+        if (null === $callbackUrl || !str_starts_with($callbackUrl, 'https://')) {
+            return null;
+        }
+
+        return $callbackUrl;
     }
 }

--- a/src/Api/UpdateOrderApi.php
+++ b/src/Api/UpdateOrderApi.php
@@ -13,11 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\PayPalPlugin\Api;
 
-use Sylius\Component\Core\Model\AdjustmentInterface;
-use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\PayPalPlugin\Client\PayPalClientInterface;
-use Sylius\PayPalPlugin\Model\PayPalPurchaseUnit;
+use Sylius\PayPalPlugin\Factory\PayPalPurchaseUnitFactory;
+use Sylius\PayPalPlugin\Factory\PayPalPurchaseUnitFactoryInterface;
 use Sylius\PayPalPlugin\Provider\PaymentReferenceNumberProviderInterface;
 use Sylius\PayPalPlugin\Provider\PayPalItemDataProviderInterface;
 
@@ -27,7 +26,16 @@ final readonly class UpdateOrderApi implements UpdateOrderApiInterface
         private PayPalClientInterface $client,
         private PaymentReferenceNumberProviderInterface $paymentReferenceNumberProvider,
         private PayPalItemDataProviderInterface $payPalItemsDataProvider,
+        private ?PayPalPurchaseUnitFactoryInterface $payPalPurchaseUnitFactory = null,
     ) {
+        if (null === $this->payPalPurchaseUnitFactory) {
+            trigger_deprecation(
+                'sylius/paypal-plugin',
+                '2.1',
+                'Not passing $payPalPurchaseUnitFactory to "%s" constructor is deprecated and will be prohibited in 3.0',
+                self::class,
+            );
+        }
     }
 
     public function update(
@@ -37,30 +45,7 @@ final readonly class UpdateOrderApi implements UpdateOrderApiInterface
         string $referenceId,
         string $merchantId,
     ): array {
-        /** @var OrderInterface $order */
-        $order = $payment->getOrder();
-
-        $payPalItemData = $this->payPalItemsDataProvider->provide($order);
-
-        $shippingDiscount = $order->getAdjustmentsTotalRecursively(
-            AdjustmentInterface::ORDER_SHIPPING_PROMOTION_ADJUSTMENT,
-        );
-
-        $data = new PayPalPurchaseUnit(
-            $referenceId,
-            $this->paymentReferenceNumberProvider->provide($payment),
-            (string) $order->getCurrencyCode(),
-            (int) $payment->getAmount(),
-            $order->getShippingTotal() - $shippingDiscount,
-            (float) $payPalItemData['total_item_value'],
-            (float) $payPalItemData['total_tax'],
-            $order->getOrderPromotionTotal(),
-            $merchantId,
-            (array) $payPalItemData['items'],
-            $order->isShippingRequired(),
-            $order->getShippingAddress(),
-            shippingDiscountValue: $shippingDiscount,
-        );
+        $payPalPurchaseUnit = $this->getPayPalPurchaseUnitFactory()->create($payment, $referenceId, $merchantId);
 
         return $this->client->patch(
             sprintf('v2/checkout/orders/%s', $orderId),
@@ -69,9 +54,17 @@ final readonly class UpdateOrderApi implements UpdateOrderApiInterface
                 [
                     'op' => 'replace',
                     'path' => sprintf('/purchase_units/@reference_id==\'%s\'', $referenceId),
-                    'value' => $data->toArray(),
+                    'value' => $payPalPurchaseUnit->toArray(),
                 ],
             ],
+        );
+    }
+
+    private function getPayPalPurchaseUnitFactory(): PayPalPurchaseUnitFactoryInterface
+    {
+        return $this->payPalPurchaseUnitFactory ?? new PayPalPurchaseUnitFactory(
+            $this->paymentReferenceNumberProvider,
+            $this->payPalItemsDataProvider,
         );
     }
 }

--- a/src/Controller/PayPalOrderShippingCallbackAction.php
+++ b/src/Controller/PayPalOrderShippingCallbackAction.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PayPalPlugin\Controller;
+
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\PayPalPlugin\Exception\PaymentNotFoundException;
+use Sylius\PayPalPlugin\Provider\ChannelAvailableCountriesProviderInterface;
+use Sylius\PayPalPlugin\Repository\Query\PaypalPaymentQueryInterface;
+use Sylius\PayPalPlugin\Resolver\PayPalShippingAddressResolverInterface;
+use Sylius\PayPalPlugin\Resolver\PayPalShippingOptionsResolverInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final readonly class PayPalOrderShippingCallbackAction
+{
+    private const ISSUE_ADDRESS_ERROR = 'ADDRESS_ERROR';
+
+    private const ISSUE_COUNTRY_ERROR = 'COUNTRY_ERROR';
+
+    public function __construct(
+        private PaypalPaymentQueryInterface $paypalPaymentQuery,
+        private ChannelAvailableCountriesProviderInterface $availableCountriesProvider,
+        private PayPalShippingAddressResolverInterface $shippingAddressResolver,
+        private PayPalShippingOptionsResolverInterface $shippingOptionsResolver,
+    ) {
+    }
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        $payload = json_decode((string) $request->getContent(), true);
+        if (!is_array($payload)) {
+            return $this->unprocessable(self::ISSUE_ADDRESS_ERROR);
+        }
+
+        $payPalOrderId = (string) ($payload['id'] ?? '');
+        /** @var array<string, mixed> $payPalShippingAddress */
+        $payPalShippingAddress = (array) ($payload['shipping_address'] ?? []);
+        /** @var array<int, mixed> $purchaseUnits */
+        $purchaseUnits = (array) ($payload['purchase_units'] ?? []);
+
+        $order = $this->getOrder($payPalOrderId);
+        if (null === $order) {
+            return $this->unprocessable(self::ISSUE_ADDRESS_ERROR);
+        }
+
+        /** @var ChannelInterface|null $channel */
+        $channel = $order->getChannel();
+        if (null === $channel) {
+            return $this->unprocessable(self::ISSUE_ADDRESS_ERROR);
+        }
+
+        $countryCode = (string) ($payPalShippingAddress['country_code'] ?? '');
+        if (!in_array($countryCode, $this->availableCountriesProvider->provideForChannel($channel), true)) {
+            return $this->unprocessable(self::ISSUE_COUNTRY_ERROR);
+        }
+
+        $shippingOptions = $this->shippingOptionsResolver->resolve(
+            $order,
+            $this->shippingAddressResolver->resolve($payPalShippingAddress),
+        );
+
+        if ([] === $shippingOptions) {
+            return $this->unprocessable(self::ISSUE_ADDRESS_ERROR);
+        }
+
+        /** @var array<string, mixed> $purchaseUnit */
+        $purchaseUnit = (array) ($purchaseUnits[0] ?? []);
+        $purchaseUnit['shipping_options'] = $shippingOptions;
+
+        return new JsonResponse([
+            'id' => $payPalOrderId,
+            'purchase_units' => [$purchaseUnit],
+        ]);
+    }
+
+    private function getOrder(string $payPalOrderId): ?OrderInterface
+    {
+        try {
+            $payment = $this->paypalPaymentQuery->getForUpdateByOrderId($payPalOrderId);
+        } catch (PaymentNotFoundException) {
+            return null;
+        }
+
+        /** @var OrderInterface|null $order */
+        $order = $payment?->getOrder();
+
+        return $order;
+    }
+
+    private function unprocessable(string $issue): JsonResponse
+    {
+        return new JsonResponse(
+            ['name' => 'UNPROCESSABLE_ENTITY', 'details' => [['issue' => $issue]]],
+            Response::HTTP_UNPROCESSABLE_ENTITY,
+        );
+    }
+}

--- a/src/Controller/PayPalOrderShippingCallbackAction.php
+++ b/src/Controller/PayPalOrderShippingCallbackAction.php
@@ -17,6 +17,7 @@ use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\PayPalPlugin\Exception\PaymentNotFoundException;
 use Sylius\PayPalPlugin\Factory\PayPalShippingAddressFactoryInterface;
+use Sylius\PayPalPlugin\Factory\PayPalShippingCallbackResponseFactoryInterface;
 use Sylius\PayPalPlugin\Provider\ChannelAvailableCountriesProviderInterface;
 use Sylius\PayPalPlugin\Repository\Query\PaypalPaymentQueryInterface;
 use Sylius\PayPalPlugin\Resolver\PayPalShippingOptionsResolverInterface;
@@ -35,6 +36,7 @@ final readonly class PayPalOrderShippingCallbackAction
         private ChannelAvailableCountriesProviderInterface $availableCountriesProvider,
         private PayPalShippingAddressFactoryInterface $shippingAddressFactory,
         private PayPalShippingOptionsResolverInterface $shippingOptionsResolver,
+        private PayPalShippingCallbackResponseFactoryInterface $responseFactory,
     ) {
     }
 
@@ -79,10 +81,7 @@ final readonly class PayPalOrderShippingCallbackAction
         /** @var array<string, mixed> $purchaseUnit */
         $purchaseUnit = (array) ($purchaseUnits[0] ?? []);
 
-        return new JsonResponse([
-            'id' => $payPalOrderId,
-            'purchase_units' => [$this->buildPurchaseUnit($purchaseUnit, $shippingOptions)],
-        ]);
+        return new JsonResponse($this->responseFactory->create($payPalOrderId, $purchaseUnit, $shippingOptions));
     }
 
     private function getOrder(string $payPalOrderId): ?OrderInterface
@@ -97,70 +96,6 @@ final readonly class PayPalOrderShippingCallbackAction
         $order = $payment?->getOrder();
 
         return $order;
-    }
-
-    /**
-     * @param array<string, mixed> $purchaseUnit
-     * @param array<int, array<string, mixed>> $shippingOptions
-     *
-     * @return array<string, mixed>
-     */
-    private function buildPurchaseUnit(array $purchaseUnit, array $shippingOptions): array
-    {
-        $responseUnit = [];
-
-        if (isset($purchaseUnit['reference_id'])) {
-            $responseUnit['reference_id'] = $purchaseUnit['reference_id'];
-        }
-
-        $responseUnit['amount'] = $this->withSelectedShippingCost(
-            (array) ($purchaseUnit['amount'] ?? []),
-            $shippingOptions,
-        );
-        $responseUnit['shipping_options'] = $shippingOptions;
-
-        return $responseUnit;
-    }
-
-    /**
-     * @param array<int, array<string, mixed>> $shippingOptions
-     * @param array<string, mixed> $amount
-     *
-     * @return array<string, mixed>
-     */
-    private function withSelectedShippingCost(array $amount, array $shippingOptions): array
-    {
-        /** @var array<string, mixed>|null $selected */
-        $selected = array_values(array_filter($shippingOptions, fn (array $option): bool => true === $option['selected']))[0] ?? null;
-
-        /** @var array<string, array<string, mixed>> $breakdown */
-        $breakdown = (array) ($amount['breakdown'] ?? []);
-        if (null === $selected || [] === $breakdown) {
-            return $amount;
-        }
-
-        $breakdown['shipping'] = (array) $selected['amount'];
-
-        $total =
-            $this->minorUnits($breakdown, 'item_total') +
-            $this->minorUnits($breakdown, 'tax_total') +
-            $this->minorUnits($breakdown, 'shipping') +
-            $this->minorUnits($breakdown, 'handling') +
-            $this->minorUnits($breakdown, 'insurance') -
-            $this->minorUnits($breakdown, 'discount') -
-            $this->minorUnits($breakdown, 'shipping_discount')
-        ;
-
-        $amount['breakdown'] = $breakdown;
-        $amount['value'] = number_format($total / 100, 2, '.', '');
-
-        return $amount;
-    }
-
-    /** @param array<string, array<string, mixed>> $breakdown */
-    private function minorUnits(array $breakdown, string $key): int
-    {
-        return (int) round(((float) ($breakdown[$key]['value'] ?? 0)) * 100);
     }
 
     private function unprocessable(string $issue): JsonResponse

--- a/src/Controller/PayPalOrderShippingCallbackAction.php
+++ b/src/Controller/PayPalOrderShippingCallbackAction.php
@@ -78,11 +78,10 @@ final readonly class PayPalOrderShippingCallbackAction
 
         /** @var array<string, mixed> $purchaseUnit */
         $purchaseUnit = (array) ($purchaseUnits[0] ?? []);
-        $purchaseUnit['shipping_options'] = $shippingOptions;
 
         return new JsonResponse([
             'id' => $payPalOrderId,
-            'purchase_units' => [$purchaseUnit],
+            'purchase_units' => [$this->buildPurchaseUnit($purchaseUnit, $shippingOptions)],
         ]);
     }
 
@@ -98,6 +97,70 @@ final readonly class PayPalOrderShippingCallbackAction
         $order = $payment?->getOrder();
 
         return $order;
+    }
+
+    /**
+     * @param array<string, mixed> $purchaseUnit
+     * @param array<int, array<string, mixed>> $shippingOptions
+     *
+     * @return array<string, mixed>
+     */
+    private function buildPurchaseUnit(array $purchaseUnit, array $shippingOptions): array
+    {
+        $responseUnit = [];
+
+        if (isset($purchaseUnit['reference_id'])) {
+            $responseUnit['reference_id'] = $purchaseUnit['reference_id'];
+        }
+
+        $responseUnit['amount'] = $this->withSelectedShippingCost(
+            (array) ($purchaseUnit['amount'] ?? []),
+            $shippingOptions,
+        );
+        $responseUnit['shipping_options'] = $shippingOptions;
+
+        return $responseUnit;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $shippingOptions
+     * @param array<string, mixed> $amount
+     *
+     * @return array<string, mixed>
+     */
+    private function withSelectedShippingCost(array $amount, array $shippingOptions): array
+    {
+        /** @var array<string, mixed>|null $selected */
+        $selected = array_values(array_filter($shippingOptions, fn (array $option): bool => true === $option['selected']))[0] ?? null;
+
+        /** @var array<string, array<string, mixed>> $breakdown */
+        $breakdown = (array) ($amount['breakdown'] ?? []);
+        if (null === $selected || [] === $breakdown) {
+            return $amount;
+        }
+
+        $breakdown['shipping'] = (array) $selected['amount'];
+
+        $total =
+            $this->minorUnits($breakdown, 'item_total') +
+            $this->minorUnits($breakdown, 'tax_total') +
+            $this->minorUnits($breakdown, 'shipping') +
+            $this->minorUnits($breakdown, 'handling') +
+            $this->minorUnits($breakdown, 'insurance') -
+            $this->minorUnits($breakdown, 'discount') -
+            $this->minorUnits($breakdown, 'shipping_discount')
+        ;
+
+        $amount['breakdown'] = $breakdown;
+        $amount['value'] = number_format($total / 100, 2, '.', '');
+
+        return $amount;
+    }
+
+    /** @param array<string, array<string, mixed>> $breakdown */
+    private function minorUnits(array $breakdown, string $key): int
+    {
+        return (int) round(((float) ($breakdown[$key]['value'] ?? 0)) * 100);
     }
 
     private function unprocessable(string $issue): JsonResponse

--- a/src/Controller/PayPalOrderShippingCallbackAction.php
+++ b/src/Controller/PayPalOrderShippingCallbackAction.php
@@ -16,9 +16,9 @@ namespace Sylius\PayPalPlugin\Controller;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\PayPalPlugin\Exception\PaymentNotFoundException;
+use Sylius\PayPalPlugin\Factory\PayPalShippingAddressFactoryInterface;
 use Sylius\PayPalPlugin\Provider\ChannelAvailableCountriesProviderInterface;
 use Sylius\PayPalPlugin\Repository\Query\PaypalPaymentQueryInterface;
-use Sylius\PayPalPlugin\Resolver\PayPalShippingAddressResolverInterface;
 use Sylius\PayPalPlugin\Resolver\PayPalShippingOptionsResolverInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -33,7 +33,7 @@ final readonly class PayPalOrderShippingCallbackAction
     public function __construct(
         private PaypalPaymentQueryInterface $paypalPaymentQuery,
         private ChannelAvailableCountriesProviderInterface $availableCountriesProvider,
-        private PayPalShippingAddressResolverInterface $shippingAddressResolver,
+        private PayPalShippingAddressFactoryInterface $shippingAddressFactory,
         private PayPalShippingOptionsResolverInterface $shippingOptionsResolver,
     ) {
     }
@@ -69,7 +69,7 @@ final readonly class PayPalOrderShippingCallbackAction
 
         $shippingOptions = $this->shippingOptionsResolver->resolve(
             $order,
-            $this->shippingAddressResolver->resolve($payPalShippingAddress),
+            $this->shippingAddressFactory->create($payPalShippingAddress),
         );
 
         if ([] === $shippingOptions) {

--- a/src/Controller/ProcessPayPalOrderAction.php
+++ b/src/Controller/ProcessPayPalOrderAction.php
@@ -33,9 +33,9 @@ use Sylius\PayPalPlugin\Api\CacheAuthorizeClientApiInterface;
 use Sylius\PayPalPlugin\Api\OrderDetailsApiInterface;
 use Sylius\PayPalPlugin\Completer\PayPalExpressOrderCompleterInterface;
 use Sylius\PayPalPlugin\Exception\PaymentAmountMismatchException;
+use Sylius\PayPalPlugin\Factory\PayPalShippingAddressFactoryInterface;
 use Sylius\PayPalPlugin\Manager\PaymentStateManagerInterface;
 use Sylius\PayPalPlugin\Provider\OrderProviderInterface;
-use Sylius\PayPalPlugin\Resolver\PayPalShippingAddressResolverInterface;
 use Sylius\PayPalPlugin\Verifier\PaymentAmountVerifierInterface;
 use Sylius\Resource\Factory\FactoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -65,7 +65,7 @@ final readonly class ProcessPayPalOrderAction
         private ?PayPalExpressOrderCompleterInterface $orderCompleter = null,
         private ?OrderProcessorInterface $orderProcessor = null,
         private ?RepositoryInterface $shippingMethodRepository = null,
-        private ?PayPalShippingAddressResolverInterface $shippingAddressResolver = null,
+        private ?PayPalShippingAddressFactoryInterface $shippingAddressFactory = null,
     ) {
         if (null === $this->paymentAmountVerifier) {
             trigger_deprecation(
@@ -109,11 +109,11 @@ final readonly class ProcessPayPalOrderAction
                 self::class,
             );
         }
-        if (null === $this->shippingAddressResolver) {
+        if (null === $this->shippingAddressFactory) {
             trigger_deprecation(
                 'sylius/paypal-plugin',
                 '2.1',
-                'Not passing $shippingAddressResolver to "%s" constructor is deprecated and will be prohibited in 3.0',
+                'Not passing $shippingAddressFactory to "%s" constructor is deprecated and will be prohibited in 3.0',
                 self::class,
             );
         }
@@ -286,14 +286,14 @@ final readonly class ProcessPayPalOrderAction
     /** @param array<string, mixed> $payPalAddress */
     private function applyProvince(AddressInterface $address, array $payPalAddress): void
     {
-        if (null === $this->shippingAddressResolver) {
+        if (null === $this->shippingAddressFactory) {
             return;
         }
 
-        $resolved = $this->shippingAddressResolver->resolve($payPalAddress);
+        $payPalShippingAddress = $this->shippingAddressFactory->create($payPalAddress);
 
-        $address->setProvinceCode($resolved->getProvinceCode());
-        $address->setProvinceName($resolved->getProvinceName());
+        $address->setProvinceCode($payPalShippingAddress->getProvinceCode());
+        $address->setProvinceName($payPalShippingAddress->getProvinceName());
     }
 
     private function abandonPayment(OrderInterface $order, PaymentInterface $payment): void

--- a/src/Controller/ProcessPayPalOrderAction.php
+++ b/src/Controller/ProcessPayPalOrderAction.php
@@ -21,11 +21,14 @@ use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
+use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Core\OrderCheckoutStates;
 use Sylius\Component\Core\OrderCheckoutTransitions;
 use Sylius\Component\Core\Repository\CustomerRepositoryInterface;
 use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Sylius\Component\Payment\PaymentTransitions;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Sylius\Component\Shipping\Model\ShippingMethodInterface;
 use Sylius\PayPalPlugin\Api\CacheAuthorizeClientApiInterface;
 use Sylius\PayPalPlugin\Api\OrderDetailsApiInterface;
 use Sylius\PayPalPlugin\Completer\PayPalExpressOrderCompleterInterface;
@@ -60,6 +63,7 @@ final readonly class ProcessPayPalOrderAction
         private ?UrlGeneratorInterface $router = null,
         private ?PayPalExpressOrderCompleterInterface $orderCompleter = null,
         private ?OrderProcessorInterface $orderProcessor = null,
+        private ?RepositoryInterface $shippingMethodRepository = null,
     ) {
         if (null === $this->paymentAmountVerifier) {
             trigger_deprecation(
@@ -92,6 +96,14 @@ final readonly class ProcessPayPalOrderAction
                 'sylius/paypal-plugin',
                 '2.1',
                 'Not passing $orderProcessor to "%s" constructor is deprecated and will be prohibited in 3.0',
+                self::class,
+            );
+        }
+        if (null === $this->shippingMethodRepository) {
+            trigger_deprecation(
+                'sylius/paypal-plugin',
+                '2.1',
+                'Not passing $shippingMethodRepository to "%s" constructor is deprecated and will be prohibited in 3.0',
                 self::class,
             );
         }
@@ -153,6 +165,8 @@ final readonly class ProcessPayPalOrderAction
             $order->setBillingAddress(clone $address);
 
             $this->stateMachineFactory->apply($order, OrderCheckoutTransitions::GRAPH, OrderCheckoutTransitions::TRANSITION_ADDRESS);
+
+            $this->applyShippingMethodSelectedInWallet($order, $purchaseUnit);
 
             if ($this->stateMachineFactory->can($order, OrderCheckoutTransitions::GRAPH, OrderCheckoutTransitions::TRANSITION_SELECT_SHIPPING)) {
                 $this->stateMachineFactory->apply($order, OrderCheckoutTransitions::GRAPH, OrderCheckoutTransitions::TRANSITION_SELECT_SHIPPING);
@@ -222,6 +236,40 @@ final readonly class ProcessPayPalOrderAction
             'return_url' => $this->generateReturnUrl('sylius_shop_checkout_complete'),
             'orderID' => $orderId, // BC with 2.0. Deprecated in 2.1; use "syliusOrderId" instead.
         ], $status);
+    }
+
+    /** @param array<string, mixed> $purchaseUnit */
+    private function applyShippingMethodSelectedInWallet(OrderInterface $order, array $purchaseUnit): void
+    {
+        if (null === $this->shippingMethodRepository) {
+            return;
+        }
+
+        /** @var array<int, array<string, mixed>> $options */
+        $options = (array) ($purchaseUnit['shipping']['options'] ?? []);
+
+        $selectedCode = null;
+        foreach ($options as $option) {
+            if (true === ($option['selected'] ?? false)) {
+                $selectedCode = (string) ($option['id'] ?? '');
+
+                break;
+            }
+        }
+
+        if (null === $selectedCode || '' === $selectedCode) {
+            return;
+        }
+
+        $shipment = $order->getShipments()->first();
+        if (!$shipment instanceof ShipmentInterface) {
+            return;
+        }
+
+        $shippingMethod = $this->shippingMethodRepository->findOneBy(['code' => $selectedCode]);
+        if ($shippingMethod instanceof ShippingMethodInterface) {
+            $shipment->setMethod($shippingMethod);
+        }
     }
 
     private function abandonPayment(OrderInterface $order, PaymentInterface $payment): void

--- a/src/Controller/ProcessPayPalOrderAction.php
+++ b/src/Controller/ProcessPayPalOrderAction.php
@@ -35,6 +35,7 @@ use Sylius\PayPalPlugin\Completer\PayPalExpressOrderCompleterInterface;
 use Sylius\PayPalPlugin\Exception\PaymentAmountMismatchException;
 use Sylius\PayPalPlugin\Manager\PaymentStateManagerInterface;
 use Sylius\PayPalPlugin\Provider\OrderProviderInterface;
+use Sylius\PayPalPlugin\Resolver\PayPalShippingAddressResolverInterface;
 use Sylius\PayPalPlugin\Verifier\PaymentAmountVerifierInterface;
 use Sylius\Resource\Factory\FactoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -64,6 +65,7 @@ final readonly class ProcessPayPalOrderAction
         private ?PayPalExpressOrderCompleterInterface $orderCompleter = null,
         private ?OrderProcessorInterface $orderProcessor = null,
         private ?RepositoryInterface $shippingMethodRepository = null,
+        private ?PayPalShippingAddressResolverInterface $shippingAddressResolver = null,
     ) {
         if (null === $this->paymentAmountVerifier) {
             trigger_deprecation(
@@ -104,6 +106,14 @@ final readonly class ProcessPayPalOrderAction
                 'sylius/paypal-plugin',
                 '2.1',
                 'Not passing $shippingMethodRepository to "%s" constructor is deprecated and will be prohibited in 3.0',
+                self::class,
+            );
+        }
+        if (null === $this->shippingAddressResolver) {
+            trigger_deprecation(
+                'sylius/paypal-plugin',
+                '2.1',
+                'Not passing $shippingAddressResolver to "%s" constructor is deprecated and will be prohibited in 3.0',
                 self::class,
             );
         }
@@ -160,6 +170,7 @@ final readonly class ProcessPayPalOrderAction
             $address->setCity($purchaseUnit['shipping']['address']['admin_area_2']);
             $address->setPostcode($purchaseUnit['shipping']['address']['postal_code']);
             $address->setCountryCode($purchaseUnit['shipping']['address']['country_code']);
+            $this->applyProvince($address, (array) $purchaseUnit['shipping']['address']);
 
             $order->setShippingAddress(clone $address);
             $order->setBillingAddress(clone $address);
@@ -270,6 +281,19 @@ final readonly class ProcessPayPalOrderAction
         if ($shippingMethod instanceof ShippingMethodInterface) {
             $shipment->setMethod($shippingMethod);
         }
+    }
+
+    /** @param array<string, mixed> $payPalAddress */
+    private function applyProvince(AddressInterface $address, array $payPalAddress): void
+    {
+        if (null === $this->shippingAddressResolver) {
+            return;
+        }
+
+        $resolved = $this->shippingAddressResolver->resolve($payPalAddress);
+
+        $address->setProvinceCode($resolved->getProvinceCode());
+        $address->setProvinceName($resolved->getProvinceName());
     }
 
     private function abandonPayment(OrderInterface $order, PaymentInterface $payment): void

--- a/src/Controller/UpdatePayPalOrderAction.php
+++ b/src/Controller/UpdatePayPalOrderAction.php
@@ -66,7 +66,7 @@ final readonly class UpdatePayPalOrderAction
             'sylius/paypal-plugin',
             '2.1',
             'The "sylius_paypal_shop_update_paypal_order" route is deprecated and will be removed in 3.0.' .
-            ' Use "sylius_paypal_shop_order_shipping_callback", the server-side shipping callback PayPal' .
+            ' Use "sylius_paypal_order_shipping_callback", the server-side shipping callback PayPal' .
             ' calls on its own, instead.',
         );
 

--- a/src/Controller/UpdatePayPalOrderAction.php
+++ b/src/Controller/UpdatePayPalOrderAction.php
@@ -62,6 +62,14 @@ final readonly class UpdatePayPalOrderAction
 
     public function __invoke(Request $request): Response
     {
+        trigger_deprecation(
+            'sylius/paypal-plugin',
+            '2.1',
+            'The "sylius_paypal_shop_update_paypal_order" route is deprecated and will be removed in 3.0.' .
+            ' Use "sylius_paypal_shop_order_shipping_callback", the server-side shipping callback PayPal' .
+            ' calls on its own, instead.',
+        );
+
         $payload = $request->getPayload();
         $orderId = $payload->getString('orderID');
 

--- a/src/Factory/PayPalOrderFactory.php
+++ b/src/Factory/PayPalOrderFactory.php
@@ -16,6 +16,7 @@ namespace Sylius\PayPalPlugin\Factory;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\PayPalPlugin\Model\PayPalOrder;
+use Sylius\PayPalPlugin\Provider\PayPalShippingCallbackUrlProviderInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 final readonly class PayPalOrderFactory implements PayPalOrderFactoryInterface
@@ -23,6 +24,7 @@ final readonly class PayPalOrderFactory implements PayPalOrderFactoryInterface
     public function __construct(
         private PayPalPurchaseUnitFactoryInterface $payPalPurchaseUnitFactory,
         private ?UrlGeneratorInterface $router = null,
+        private ?PayPalShippingCallbackUrlProviderInterface $shippingCallbackUrlProvider = null,
     ) {
     }
 
@@ -43,22 +45,7 @@ final readonly class PayPalOrderFactory implements PayPalOrderFactoryInterface
             PayPalOrder::INTENT_CAPTURE,
             $payerReturnUrl,
             $payerReturnUrl,
-            $this->getShippingCallbackUrl(),
+            $this->shippingCallbackUrlProvider?->provide(),
         );
-    }
-
-    private function getShippingCallbackUrl(): ?string
-    {
-        $callbackUrl = $this->router?->generate(
-            'sylius_paypal_shop_order_shipping_callback',
-            [],
-            UrlGeneratorInterface::ABSOLUTE_URL,
-        );
-
-        if (null === $callbackUrl || !str_starts_with($callbackUrl, 'https://')) {
-            return null;
-        }
-
-        return $callbackUrl;
     }
 }

--- a/src/Factory/PayPalOrderFactory.php
+++ b/src/Factory/PayPalOrderFactory.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PayPalPlugin\Factory;
+
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\PayPalPlugin\Model\PayPalOrder;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final readonly class PayPalOrderFactory implements PayPalOrderFactoryInterface
+{
+    public function __construct(
+        private PayPalPurchaseUnitFactoryInterface $payPalPurchaseUnitFactory,
+        private ?UrlGeneratorInterface $router = null,
+    ) {
+    }
+
+    public function create(PaymentInterface $payment, string $referenceId): PayPalOrder
+    {
+        /** @var OrderInterface $order */
+        $order = $payment->getOrder();
+
+        $payerReturnUrl = $this->router?->generate(
+            'sylius_shop_checkout_complete',
+            [],
+            UrlGeneratorInterface::ABSOLUTE_URL,
+        );
+
+        return new PayPalOrder(
+            $order,
+            $this->payPalPurchaseUnitFactory->create($payment, $referenceId),
+            PayPalOrder::INTENT_CAPTURE,
+            $payerReturnUrl,
+            $payerReturnUrl,
+            $this->getShippingCallbackUrl(),
+        );
+    }
+
+    private function getShippingCallbackUrl(): ?string
+    {
+        $callbackUrl = $this->router?->generate(
+            'sylius_paypal_shop_order_shipping_callback',
+            [],
+            UrlGeneratorInterface::ABSOLUTE_URL,
+        );
+
+        if (null === $callbackUrl || !str_starts_with($callbackUrl, 'https://')) {
+            return null;
+        }
+
+        return $callbackUrl;
+    }
+}

--- a/src/Factory/PayPalOrderFactoryInterface.php
+++ b/src/Factory/PayPalOrderFactoryInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PayPalPlugin\Factory;
+
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\PayPalPlugin\Model\PayPalOrder;
+
+interface PayPalOrderFactoryInterface
+{
+    public function create(PaymentInterface $payment, string $referenceId): PayPalOrder;
+}

--- a/src/Factory/PayPalPurchaseUnitFactory.php
+++ b/src/Factory/PayPalPurchaseUnitFactory.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PayPalPlugin\Factory;
+
+use Sylius\Bundle\PayumBundle\Model\GatewayConfigInterface;
+use Sylius\Component\Core\Model\AdjustmentInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\Model\PaymentMethodInterface;
+use Sylius\PayPalPlugin\Model\PayPalPurchaseUnit;
+use Sylius\PayPalPlugin\Provider\PaymentReferenceNumberProviderInterface;
+use Sylius\PayPalPlugin\Provider\PayPalItemDataProviderInterface;
+use Webmozart\Assert\Assert;
+
+final readonly class PayPalPurchaseUnitFactory implements PayPalPurchaseUnitFactoryInterface
+{
+    public function __construct(
+        private PaymentReferenceNumberProviderInterface $paymentReferenceNumberProvider,
+        private PayPalItemDataProviderInterface $payPalItemDataProvider,
+    ) {
+    }
+
+    public function create(
+        PaymentInterface $payment,
+        string $referenceId,
+        ?string $merchantId = null,
+    ): PayPalPurchaseUnit {
+        /** @var OrderInterface $order */
+        $order = $payment->getOrder();
+
+        $payPalItemData = $this->payPalItemDataProvider->provide($order);
+
+        $shippingDiscount = $order->getAdjustmentsTotalRecursively(
+            AdjustmentInterface::ORDER_SHIPPING_PROMOTION_ADJUSTMENT,
+        );
+
+        return new PayPalPurchaseUnit(
+            $referenceId,
+            $this->paymentReferenceNumberProvider->provide($payment),
+            (string) $order->getCurrencyCode(),
+            (int) $payment->getAmount(),
+            $order->getShippingTotal() - $shippingDiscount,
+            (float) $payPalItemData['total_item_value'],
+            (float) $payPalItemData['total_tax'],
+            $order->getOrderPromotionTotal(),
+            $merchantId ?? $this->getMerchantId($payment),
+            (array) $payPalItemData['items'],
+            $order->isShippingRequired(),
+            $order->getShippingAddress(),
+            shippingDiscountValue: $shippingDiscount,
+        );
+    }
+
+    private function getMerchantId(PaymentInterface $payment): string
+    {
+        /** @var PaymentMethodInterface $paymentMethod */
+        $paymentMethod = $payment->getMethod();
+
+        /** @var GatewayConfigInterface $gatewayConfig */
+        $gatewayConfig = $paymentMethod->getGatewayConfig();
+
+        $config = $gatewayConfig->getConfig();
+
+        Assert::keyExists($config, 'merchant_id');
+        Assert::keyExists($config, 'sylius_merchant_id');
+
+        return (string) $config['merchant_id'];
+    }
+}

--- a/src/Factory/PayPalPurchaseUnitFactoryInterface.php
+++ b/src/Factory/PayPalPurchaseUnitFactoryInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PayPalPlugin\Factory;
+
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\PayPalPlugin\Model\PayPalPurchaseUnit;
+
+interface PayPalPurchaseUnitFactoryInterface
+{
+    public function create(
+        PaymentInterface $payment,
+        string $referenceId,
+        ?string $merchantId = null,
+    ): PayPalPurchaseUnit;
+}

--- a/src/Factory/PayPalShippingAddressFactory.php
+++ b/src/Factory/PayPalShippingAddressFactory.php
@@ -11,13 +11,13 @@
 
 declare(strict_types=1);
 
-namespace Sylius\PayPalPlugin\Resolver;
+namespace Sylius\PayPalPlugin\Factory;
 
 use Sylius\Component\Core\Factory\AddressFactoryInterface;
 use Sylius\Component\Core\Model\AddressInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 
-final readonly class PayPalShippingAddressResolver implements PayPalShippingAddressResolverInterface
+final readonly class PayPalShippingAddressFactory implements PayPalShippingAddressFactoryInterface
 {
     /** @param AddressFactoryInterface<AddressInterface> $addressFactory */
     public function __construct(
@@ -26,7 +26,7 @@ final readonly class PayPalShippingAddressResolver implements PayPalShippingAddr
     ) {
     }
 
-    public function resolve(array $payPalShippingAddress): AddressInterface
+    public function create(array $payPalShippingAddress): AddressInterface
     {
         $countryCode = $this->stringOrNull($payPalShippingAddress['country_code'] ?? null);
 

--- a/src/Factory/PayPalShippingAddressFactoryInterface.php
+++ b/src/Factory/PayPalShippingAddressFactoryInterface.php
@@ -11,12 +11,12 @@
 
 declare(strict_types=1);
 
-namespace Sylius\PayPalPlugin\Resolver;
+namespace Sylius\PayPalPlugin\Factory;
 
 use Sylius\Component\Core\Model\AddressInterface;
 
-interface PayPalShippingAddressResolverInterface
+interface PayPalShippingAddressFactoryInterface
 {
     /** @param array<string, mixed> $payPalShippingAddress */
-    public function resolve(array $payPalShippingAddress): AddressInterface;
+    public function create(array $payPalShippingAddress): AddressInterface;
 }

--- a/src/Factory/PayPalShippingCallbackResponseFactory.php
+++ b/src/Factory/PayPalShippingCallbackResponseFactory.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PayPalPlugin\Factory;
+
+final readonly class PayPalShippingCallbackResponseFactory implements PayPalShippingCallbackResponseFactoryInterface
+{
+    private const ADDED_BREAKDOWN_KEYS = ['item_total', 'tax_total', 'shipping', 'handling', 'insurance'];
+
+    private const SUBTRACTED_BREAKDOWN_KEYS = ['discount', 'shipping_discount'];
+
+    public function create(string $payPalOrderId, array $purchaseUnit, array $shippingOptions): array
+    {
+        return [
+            'id' => $payPalOrderId,
+            'purchase_units' => [$this->createPurchaseUnit($purchaseUnit, $shippingOptions)],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $purchaseUnit
+     * @param array<int, array<string, mixed>> $shippingOptions
+     *
+     * @return array<string, mixed>
+     */
+    private function createPurchaseUnit(array $purchaseUnit, array $shippingOptions): array
+    {
+        $responseUnit = [];
+
+        if (isset($purchaseUnit['reference_id'])) {
+            $responseUnit['reference_id'] = $purchaseUnit['reference_id'];
+        }
+
+        $responseUnit['amount'] = $this->withSelectedShippingCost(
+            (array) ($purchaseUnit['amount'] ?? []),
+            $shippingOptions,
+        );
+        $responseUnit['shipping_options'] = $shippingOptions;
+
+        return $responseUnit;
+    }
+
+    /**
+     * @param array<string, mixed> $amount
+     * @param array<int, array<string, mixed>> $shippingOptions
+     *
+     * @return array<string, mixed>
+     */
+    private function withSelectedShippingCost(array $amount, array $shippingOptions): array
+    {
+        $selected = $this->getSelectedOption($shippingOptions);
+
+        /** @var array<string, array<string, mixed>> $breakdown */
+        $breakdown = (array) ($amount['breakdown'] ?? []);
+        if (null === $selected || [] === $breakdown) {
+            return $amount;
+        }
+
+        $breakdown['shipping'] = (array) $selected['amount'];
+
+        $total = 0;
+        foreach (self::ADDED_BREAKDOWN_KEYS as $key) {
+            $total += $this->minorUnits($breakdown, $key);
+        }
+        foreach (self::SUBTRACTED_BREAKDOWN_KEYS as $key) {
+            $total -= $this->minorUnits($breakdown, $key);
+        }
+
+        $amount['breakdown'] = $breakdown;
+        $amount['value'] = number_format($total / 100, 2, '.', '');
+
+        return $amount;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $shippingOptions
+     *
+     * @return array<string, mixed>|null
+     */
+    private function getSelectedOption(array $shippingOptions): ?array
+    {
+        foreach ($shippingOptions as $option) {
+            if (true === ($option['selected'] ?? false)) {
+                return $option;
+            }
+        }
+
+        return null;
+    }
+
+    /** @param array<string, array<string, mixed>> $breakdown */
+    private function minorUnits(array $breakdown, string $key): int
+    {
+        return (int) round(((float) ($breakdown[$key]['value'] ?? 0)) * 100);
+    }
+}

--- a/src/Factory/PayPalShippingCallbackResponseFactory.php
+++ b/src/Factory/PayPalShippingCallbackResponseFactory.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\PayPalPlugin\Factory;
 
+use Sylius\PayPalPlugin\Model\PayPalShippingOption;
+
 final readonly class PayPalShippingCallbackResponseFactory implements PayPalShippingCallbackResponseFactoryInterface
 {
     private const ADDED_BREAKDOWN_KEYS = ['item_total', 'tax_total', 'shipping', 'handling', 'insurance'];
@@ -29,7 +31,7 @@ final readonly class PayPalShippingCallbackResponseFactory implements PayPalShip
 
     /**
      * @param array<string, mixed> $purchaseUnit
-     * @param array<int, array<string, mixed>> $shippingOptions
+     * @param array<int, PayPalShippingOption> $shippingOptions
      *
      * @return array<string, mixed>
      */
@@ -45,14 +47,17 @@ final readonly class PayPalShippingCallbackResponseFactory implements PayPalShip
             (array) ($purchaseUnit['amount'] ?? []),
             $shippingOptions,
         );
-        $responseUnit['shipping_options'] = $shippingOptions;
+        $responseUnit['shipping_options'] = array_map(
+            static fn (PayPalShippingOption $option): array => $option->toArray(),
+            $shippingOptions,
+        );
 
         return $responseUnit;
     }
 
     /**
      * @param array<string, mixed> $amount
-     * @param array<int, array<string, mixed>> $shippingOptions
+     * @param array<int, PayPalShippingOption> $shippingOptions
      *
      * @return array<string, mixed>
      */
@@ -66,7 +71,7 @@ final readonly class PayPalShippingCallbackResponseFactory implements PayPalShip
             return $amount;
         }
 
-        $breakdown['shipping'] = (array) $selected['amount'];
+        $breakdown['shipping'] = $selected->amountToArray();
 
         $total = 0;
         foreach (self::ADDED_BREAKDOWN_KEYS as $key) {
@@ -82,15 +87,11 @@ final readonly class PayPalShippingCallbackResponseFactory implements PayPalShip
         return $amount;
     }
 
-    /**
-     * @param array<int, array<string, mixed>> $shippingOptions
-     *
-     * @return array<string, mixed>|null
-     */
-    private function getSelectedOption(array $shippingOptions): ?array
+    /** @param array<int, PayPalShippingOption> $shippingOptions */
+    private function getSelectedOption(array $shippingOptions): ?PayPalShippingOption
     {
         foreach ($shippingOptions as $option) {
-            if (true === ($option['selected'] ?? false)) {
+            if ($option->isSelected()) {
                 return $option;
             }
         }

--- a/src/Factory/PayPalShippingCallbackResponseFactoryInterface.php
+++ b/src/Factory/PayPalShippingCallbackResponseFactoryInterface.php
@@ -13,11 +13,13 @@ declare(strict_types=1);
 
 namespace Sylius\PayPalPlugin\Factory;
 
+use Sylius\PayPalPlugin\Model\PayPalShippingOption;
+
 interface PayPalShippingCallbackResponseFactoryInterface
 {
     /**
      * @param array<string, mixed> $purchaseUnit
-     * @param array<int, array<string, mixed>> $shippingOptions
+     * @param array<int, PayPalShippingOption> $shippingOptions
      *
      * @return array<string, mixed>
      */

--- a/src/Factory/PayPalShippingCallbackResponseFactoryInterface.php
+++ b/src/Factory/PayPalShippingCallbackResponseFactoryInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PayPalPlugin\Factory;
+
+interface PayPalShippingCallbackResponseFactoryInterface
+{
+    /**
+     * @param array<string, mixed> $purchaseUnit
+     * @param array<int, array<string, mixed>> $shippingOptions
+     *
+     * @return array<string, mixed>
+     */
+    public function create(string $payPalOrderId, array $purchaseUnit, array $shippingOptions): array;
+}

--- a/src/Model/PayPalOrder.php
+++ b/src/Model/PayPalOrder.php
@@ -17,6 +17,8 @@ use Sylius\Component\Core\Model\OrderInterface;
 
 class PayPalOrder
 {
+    public const INTENT_CAPTURE = 'CAPTURE';
+
     public const NO_SHIPPING = 'NO_SHIPPING';
 
     public const PROVIDED_ADDRESS = 'SET_PROVIDED_ADDRESS';

--- a/src/Model/PayPalOrder.php
+++ b/src/Model/PayPalOrder.php
@@ -25,6 +25,8 @@ class PayPalOrder
 
     public const USER_ACTION_PAY_NOW = 'PAY_NOW';
 
+    public const CALLBACK_EVENT_SHIPPING_ADDRESS = 'SHIPPING_ADDRESS';
+
     /** @var string */
     private $intent;
 
@@ -40,6 +42,7 @@ class PayPalOrder
         string $intent,
         private readonly ?string $returnUrl = null,
         private readonly ?string $cancelUrl = null,
+        private readonly ?string $shippingCallbackUrl = null,
     ) {
         $this->payPalPurchaseUnit = $payPalPurchaseUnit;
         $this->order = $order;
@@ -87,6 +90,13 @@ class PayPalOrder
 
         if (null !== $this->cancelUrl) {
             $experienceContext['cancel_url'] = $this->cancelUrl;
+        }
+
+        if (null !== $this->shippingCallbackUrl) {
+            $experienceContext['order_update_callback_config'] = [
+                'callback_events' => [self::CALLBACK_EVENT_SHIPPING_ADDRESS],
+                'callback_url' => $this->shippingCallbackUrl,
+            ];
         }
 
         return $experienceContext;

--- a/src/Model/PayPalOrder.php
+++ b/src/Model/PayPalOrder.php
@@ -58,27 +58,30 @@ class PayPalOrder
             'purchase_units' => [
                 $this->payPalPurchaseUnit->toArray(),
             ],
-            'application_context' => [
-                'shipping_preference' => $shippingPreference,
-                'user_action' => self::USER_ACTION_PAY_NOW,
-            ],
         ];
 
+        // PayPal rejects an order carrying shipping_preference or user_action in both places with
+        // INCOMPATIBLE_PARAMETER_VALUE, so the two context blocks are mutually exclusive.
         if (self::PAYPAL_ADDRESS === $shippingPreference) {
             $payPalOrder['payment_source'] = [
                 'paypal' => [
                     'experience_context' => $this->getExperienceContext($shippingPreference),
                 ],
             ];
+
+            return $payPalOrder;
         }
+
+        $payPalOrder['application_context'] = [
+            'shipping_preference' => $shippingPreference,
+            'user_action' => self::USER_ACTION_PAY_NOW,
+        ];
 
         return $payPalOrder;
     }
 
     private function getExperienceContext(string $shippingPreference): array
     {
-        // experience_context supersedes application_context for the selected payment source, so both keys
-        // above are repeated here rather than relied upon.
         $experienceContext = [
             'shipping_preference' => $shippingPreference,
             'user_action' => self::USER_ACTION_PAY_NOW,

--- a/src/Model/PayPalOrder.php
+++ b/src/Model/PayPalOrder.php
@@ -38,6 +38,8 @@ class PayPalOrder
         OrderInterface $order,
         PayPalPurchaseUnit $payPalPurchaseUnit,
         string $intent,
+        private readonly ?string $returnUrl = null,
+        private readonly ?string $cancelUrl = null,
     ) {
         $this->payPalPurchaseUnit = $payPalPurchaseUnit;
         $this->order = $order;
@@ -46,16 +48,48 @@ class PayPalOrder
 
     public function toArray(): array
     {
-        return [
+        $shippingPreference = $this->getShippingPreference();
+
+        $payPalOrder = [
             'intent' => $this->intent,
             'purchase_units' => [
                 $this->payPalPurchaseUnit->toArray(),
             ],
             'application_context' => [
-                'shipping_preference' => $this->getShippingPreference(),
+                'shipping_preference' => $shippingPreference,
                 'user_action' => self::USER_ACTION_PAY_NOW,
             ],
         ];
+
+        if (self::PAYPAL_ADDRESS === $shippingPreference) {
+            $payPalOrder['payment_source'] = [
+                'paypal' => [
+                    'experience_context' => $this->getExperienceContext($shippingPreference),
+                ],
+            ];
+        }
+
+        return $payPalOrder;
+    }
+
+    private function getExperienceContext(string $shippingPreference): array
+    {
+        // experience_context supersedes application_context for the selected payment source, so both keys
+        // above are repeated here rather than relied upon.
+        $experienceContext = [
+            'shipping_preference' => $shippingPreference,
+            'user_action' => self::USER_ACTION_PAY_NOW,
+        ];
+
+        if (null !== $this->returnUrl) {
+            $experienceContext['return_url'] = $this->returnUrl;
+        }
+
+        if (null !== $this->cancelUrl) {
+            $experienceContext['cancel_url'] = $this->cancelUrl;
+        }
+
+        return $experienceContext;
     }
 
     private function getShippingPreference(): string

--- a/src/Model/PayPalShippingOption.php
+++ b/src/Model/PayPalShippingOption.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PayPalPlugin\Model;
+
+final readonly class PayPalShippingOption
+{
+    public const TYPE_SHIPPING = 'SHIPPING';
+
+    public const TYPE_PICKUP = 'PICKUP';
+
+    public function __construct(
+        private string $id,
+        private string $label,
+        private string $currencyCode,
+        private int $amount,
+        private bool $selected = false,
+        private string $type = self::TYPE_SHIPPING,
+    ) {
+    }
+
+    public function id(): string
+    {
+        return $this->id;
+    }
+
+    public function label(): string
+    {
+        return $this->label;
+    }
+
+    public function currencyCode(): string
+    {
+        return $this->currencyCode;
+    }
+
+    public function amount(): int
+    {
+        return $this->amount;
+    }
+
+    public function isSelected(): bool
+    {
+        return $this->selected;
+    }
+
+    public function type(): string
+    {
+        return $this->type;
+    }
+
+    public function withSelected(bool $selected): self
+    {
+        return new self($this->id, $this->label, $this->currencyCode, $this->amount, $selected, $this->type);
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'amount' => $this->amountToArray(),
+            'type' => $this->type,
+            'label' => $this->label,
+            'selected' => $this->selected,
+        ];
+    }
+
+    /** @return array<string, string> */
+    public function amountToArray(): array
+    {
+        return [
+            'currency_code' => $this->currencyCode,
+            'value' => number_format($this->amount / 100, 2, '.', ''),
+        ];
+    }
+}

--- a/src/Payum/Action/CaptureAction.php
+++ b/src/Payum/Action/CaptureAction.php
@@ -24,6 +24,14 @@ use Sylius\PayPalPlugin\Provider\UuidProviderInterface;
 
 final readonly class CaptureAction implements ActionInterface
 {
+    /**
+     * PayPal answers CREATED for an order created without a selected payment source, and
+     * PAYER_ACTION_REQUIRED once payment_source.paypal.experience_context is sent. Both mean the order
+     * exists and both carry its id - treating only the former as success leaves the payment without a
+     * paypal_order_id, which breaks every step that follows.
+     */
+    private const ORDER_CREATED_STATUSES = ['CREATED', 'PAYER_ACTION_REQUIRED'];
+
     public function __construct(
         private CacheAuthorizeClientApiInterface $authorizeClientApi,
         private CreateOrderApiInterface $createOrderApi,
@@ -46,7 +54,7 @@ final readonly class CaptureAction implements ActionInterface
         $referenceId = $this->uuidProvider->provide();
         $content = $this->createOrderApi->create($token, $payment, $referenceId);
 
-        if ($content['status'] === 'CREATED') {
+        if (in_array($content['status'] ?? null, self::ORDER_CREATED_STATUSES, true)) {
             $payment->setDetails([
                 'status' => StatusAction::STATUS_CAPTURED,
                 'paypal_order_id' => $content['id'],

--- a/src/Payum/Action/CaptureAction.php
+++ b/src/Payum/Action/CaptureAction.php
@@ -20,23 +20,26 @@ use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\PayPalPlugin\Api\CacheAuthorizeClientApiInterface;
 use Sylius\PayPalPlugin\Api\CreateOrderApiInterface;
+use Sylius\PayPalPlugin\Provider\PayPalOrderCreatedStatusesProvider;
+use Sylius\PayPalPlugin\Provider\PayPalOrderCreatedStatusesProviderInterface;
 use Sylius\PayPalPlugin\Provider\UuidProviderInterface;
 
 final readonly class CaptureAction implements ActionInterface
 {
-    /**
-     * PayPal answers CREATED for an order created without a selected payment source, and
-     * PAYER_ACTION_REQUIRED once payment_source.paypal.experience_context is sent. Both mean the order
-     * exists and both carry its id - treating only the former as success leaves the payment without a
-     * paypal_order_id, which breaks every step that follows.
-     */
-    private const ORDER_CREATED_STATUSES = ['CREATED', 'PAYER_ACTION_REQUIRED'];
-
     public function __construct(
         private CacheAuthorizeClientApiInterface $authorizeClientApi,
         private CreateOrderApiInterface $createOrderApi,
         private UuidProviderInterface $uuidProvider,
+        private ?PayPalOrderCreatedStatusesProviderInterface $orderCreatedStatusesProvider = null,
     ) {
+        if (null === $this->orderCreatedStatusesProvider) {
+            trigger_deprecation(
+                'sylius/paypal-plugin',
+                '2.1',
+                'Not passing $orderCreatedStatusesProvider to "%s" constructor is deprecated and will be prohibited in 3.0',
+                self::class,
+            );
+        }
     }
 
     /** @param Capture $request */
@@ -54,7 +57,7 @@ final readonly class CaptureAction implements ActionInterface
         $referenceId = $this->uuidProvider->provide();
         $content = $this->createOrderApi->create($token, $payment, $referenceId);
 
-        if (in_array($content['status'] ?? null, self::ORDER_CREATED_STATUSES, true)) {
+        if (in_array($content['status'] ?? null, $this->getOrderCreatedStatuses(), true)) {
             $payment->setDetails([
                 'status' => StatusAction::STATUS_CAPTURED,
                 'paypal_order_id' => $content['id'],
@@ -62,6 +65,14 @@ final readonly class CaptureAction implements ActionInterface
                 'payment_amount' => $payment->getAmount(),
             ]);
         }
+    }
+
+    /** @return array<int, string> */
+    private function getOrderCreatedStatuses(): array
+    {
+        $provider = $this->orderCreatedStatusesProvider ?? new PayPalOrderCreatedStatusesProvider();
+
+        return $provider->provide();
     }
 
     public function supports($request): bool

--- a/src/Provider/AvailableCountriesProvider.php
+++ b/src/Provider/AvailableCountriesProvider.php
@@ -18,7 +18,7 @@ use Sylius\Component\Channel\Context\ChannelContextInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 
-class AvailableCountriesProvider implements AvailableCountriesProviderInterface
+class AvailableCountriesProvider implements AvailableCountriesProviderInterface, ChannelAvailableCountriesProviderInterface
 {
     public function __construct(
         private readonly RepositoryInterface $countryRepository,
@@ -31,6 +31,11 @@ class AvailableCountriesProvider implements AvailableCountriesProviderInterface
         /** @var ChannelInterface $channel */
         $channel = $this->channelContext->getChannel();
 
+        return $this->provideForChannel($channel);
+    }
+
+    public function provideForChannel(ChannelInterface $channel): array
+    {
         $channelCountries = $channel->getCountries()->toArray();
 
         if (count($channelCountries)) {

--- a/src/Provider/ChannelAvailableCountriesProviderInterface.php
+++ b/src/Provider/ChannelAvailableCountriesProviderInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PayPalPlugin\Provider;
+
+use Sylius\Component\Core\Model\ChannelInterface;
+
+interface ChannelAvailableCountriesProviderInterface
+{
+    /** @return string[] */
+    public function provideForChannel(ChannelInterface $channel): array;
+}

--- a/src/Provider/PayPalOrderCreatedStatusesProvider.php
+++ b/src/Provider/PayPalOrderCreatedStatusesProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PayPalPlugin\Provider;
+
+final readonly class PayPalOrderCreatedStatusesProvider implements PayPalOrderCreatedStatusesProviderInterface
+{
+    public const STATUS_CREATED = 'CREATED';
+
+    public const STATUS_PAYER_ACTION_REQUIRED = 'PAYER_ACTION_REQUIRED';
+
+    public function provide(): array
+    {
+        return [self::STATUS_CREATED, self::STATUS_PAYER_ACTION_REQUIRED];
+    }
+}

--- a/src/Provider/PayPalOrderCreatedStatusesProviderInterface.php
+++ b/src/Provider/PayPalOrderCreatedStatusesProviderInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PayPalPlugin\Provider;
+
+interface PayPalOrderCreatedStatusesProviderInterface
+{
+    /** @return array<int, string> */
+    public function provide(): array;
+}

--- a/src/Provider/PayPalShippingCallbackUrlProvider.php
+++ b/src/Provider/PayPalShippingCallbackUrlProvider.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PayPalPlugin\Provider;
+
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final readonly class PayPalShippingCallbackUrlProvider implements PayPalShippingCallbackUrlProviderInterface
+{
+    private const REQUIRED_SCHEME = 'https';
+
+    public function __construct(
+        private UrlGeneratorInterface $router,
+        private string $route = 'sylius_paypal_shop_order_shipping_callback',
+    ) {
+    }
+
+    public function provide(): ?string
+    {
+        $callbackUrl = $this->router->generate($this->route, [], UrlGeneratorInterface::ABSOLUTE_URL);
+
+        if (!str_starts_with($callbackUrl, self::REQUIRED_SCHEME . '://')) {
+            return null;
+        }
+
+        return $callbackUrl;
+    }
+}

--- a/src/Provider/PayPalShippingCallbackUrlProvider.php
+++ b/src/Provider/PayPalShippingCallbackUrlProvider.php
@@ -21,7 +21,7 @@ final readonly class PayPalShippingCallbackUrlProvider implements PayPalShipping
 
     public function __construct(
         private UrlGeneratorInterface $router,
-        private string $route = 'sylius_paypal_shop_order_shipping_callback',
+        private string $route = 'sylius_paypal_order_shipping_callback',
     ) {
     }
 

--- a/src/Provider/PayPalShippingCallbackUrlProviderInterface.php
+++ b/src/Provider/PayPalShippingCallbackUrlProviderInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PayPalPlugin\Provider;
+
+interface PayPalShippingCallbackUrlProviderInterface
+{
+    public function provide(): ?string;
+}

--- a/src/Resolver/PayPalShippingAddressResolver.php
+++ b/src/Resolver/PayPalShippingAddressResolver.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PayPalPlugin\Resolver;
+
+use Sylius\Component\Core\Factory\AddressFactoryInterface;
+use Sylius\Component\Core\Model\AddressInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+
+final readonly class PayPalShippingAddressResolver implements PayPalShippingAddressResolverInterface
+{
+    /** @param AddressFactoryInterface<AddressInterface> $addressFactory */
+    public function __construct(
+        private AddressFactoryInterface $addressFactory,
+        private RepositoryInterface $provinceRepository,
+    ) {
+    }
+
+    public function resolve(array $payPalShippingAddress): AddressInterface
+    {
+        $countryCode = $this->stringOrNull($payPalShippingAddress['country_code'] ?? null);
+
+        /** @var AddressInterface $address */
+        $address = $this->addressFactory->createNew();
+        $address->setCountryCode($countryCode);
+        $address->setCity($this->stringOrNull($payPalShippingAddress['admin_area_2'] ?? null));
+        $address->setPostcode($this->stringOrNull($payPalShippingAddress['postal_code'] ?? null));
+        $address->setProvinceCode($this->resolveProvinceCode(
+            $countryCode,
+            $this->stringOrNull($payPalShippingAddress['admin_area_1'] ?? null),
+        ));
+
+        return $address;
+    }
+
+    private function resolveProvinceCode(?string $countryCode, ?string $adminArea1): ?string
+    {
+        if (null === $adminArea1) {
+            return null;
+        }
+
+        $candidates = null !== $countryCode ? [$countryCode . '-' . $adminArea1, $adminArea1] : [$adminArea1];
+
+        foreach ($candidates as $candidate) {
+            if (null !== $this->provinceRepository->findOneBy(['code' => $candidate])) {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }
+
+    private function stringOrNull(mixed $value): ?string
+    {
+        if (!is_scalar($value)) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        return '' === $value ? null : $value;
+    }
+}

--- a/src/Resolver/PayPalShippingAddressResolver.php
+++ b/src/Resolver/PayPalShippingAddressResolver.php
@@ -35,10 +35,11 @@ final readonly class PayPalShippingAddressResolver implements PayPalShippingAddr
         $address->setCountryCode($countryCode);
         $address->setCity($this->stringOrNull($payPalShippingAddress['admin_area_2'] ?? null));
         $address->setPostcode($this->stringOrNull($payPalShippingAddress['postal_code'] ?? null));
-        $address->setProvinceCode($this->resolveProvinceCode(
-            $countryCode,
-            $this->stringOrNull($payPalShippingAddress['admin_area_1'] ?? null),
-        ));
+        $adminArea1 = $this->stringOrNull($payPalShippingAddress['admin_area_1'] ?? null);
+        $provinceCode = $this->resolveProvinceCode($countryCode, $adminArea1);
+
+        $address->setProvinceCode($provinceCode);
+        $address->setProvinceName(null === $provinceCode ? $adminArea1 : null);
 
         return $address;
     }

--- a/src/Resolver/PayPalShippingAddressResolverInterface.php
+++ b/src/Resolver/PayPalShippingAddressResolverInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PayPalPlugin\Resolver;
+
+use Sylius\Component\Core\Model\AddressInterface;
+
+interface PayPalShippingAddressResolverInterface
+{
+    /** @param array<string, mixed> $payPalShippingAddress */
+    public function resolve(array $payPalShippingAddress): AddressInterface;
+}

--- a/src/Resolver/PayPalShippingOptionsResolver.php
+++ b/src/Resolver/PayPalShippingOptionsResolver.php
@@ -64,11 +64,24 @@ final readonly class PayPalShippingOptionsResolver implements PayPalShippingOpti
 
         return new PayPalShippingOption(
             (string) $method->getCode(),
-            (string) $method->getName(),
+            $this->getLabel($method, $order->getLocaleCode()),
             (string) $order->getCurrencyCode(),
             $this->shippingCalculator->calculate($shipment),
             $method === $currentMethod,
         );
+    }
+
+    private function getLabel(ShippingMethodInterface $method, ?string $localeCode): string
+    {
+        if (null !== $localeCode && '' !== $localeCode) {
+            $name = $method->getTranslation($localeCode)->getName();
+
+            if (null !== $name && '' !== $name) {
+                return $name;
+            }
+        }
+
+        return (string) $method->getName();
     }
 
     /**

--- a/src/Resolver/PayPalShippingOptionsResolver.php
+++ b/src/Resolver/PayPalShippingOptionsResolver.php
@@ -19,11 +19,10 @@ use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Shipping\Calculator\DelegatingCalculatorInterface;
 use Sylius\Component\Shipping\Model\ShippingMethodInterface;
 use Sylius\Component\Shipping\Resolver\ShippingMethodsResolverInterface;
+use Sylius\PayPalPlugin\Model\PayPalShippingOption;
 
 final readonly class PayPalShippingOptionsResolver implements PayPalShippingOptionsResolverInterface
 {
-    private const TYPE_SHIPPING = 'SHIPPING';
-
     public function __construct(
         private ShippingMethodsResolverInterface $shippingMethodsResolver,
         private DelegatingCalculatorInterface $shippingCalculator,
@@ -45,7 +44,7 @@ final readonly class PayPalShippingOptionsResolver implements PayPalShippingOpti
             $options = [];
 
             foreach ($this->shippingMethodsResolver->getSupportedMethods($shipment) as $method) {
-                $options[] = $this->buildOption($order, $shipment, $method, $originalMethod);
+                $options[] = $this->createOption($order, $shipment, $method, $originalMethod);
             }
         } finally {
             $shipment->setMethod($originalMethod);
@@ -55,46 +54,48 @@ final readonly class PayPalShippingOptionsResolver implements PayPalShippingOpti
         return $this->withExactlyOneSelected($options);
     }
 
-    /** @return array<string, mixed> */
-    private function buildOption(
+    private function createOption(
         OrderInterface $order,
         ShipmentInterface $shipment,
         ShippingMethodInterface $method,
         ?ShippingMethodInterface $currentMethod,
-    ): array {
+    ): PayPalShippingOption {
         $shipment->setMethod($method);
 
-        return [
-            'id' => (string) $method->getCode(),
-            'amount' => [
-                'currency_code' => (string) $order->getCurrencyCode(),
-                'value' => number_format($this->shippingCalculator->calculate($shipment) / 100, 2, '.', ''),
-            ],
-            'type' => self::TYPE_SHIPPING,
-            'label' => (string) $method->getName(),
-            'selected' => $method === $currentMethod,
-        ];
+        return new PayPalShippingOption(
+            (string) $method->getCode(),
+            (string) $method->getName(),
+            (string) $order->getCurrencyCode(),
+            $this->shippingCalculator->calculate($shipment),
+            $method === $currentMethod,
+        );
     }
 
     /**
-     * @param array<int, array<string, mixed>> $options
+     * @param array<int, PayPalShippingOption> $options
      *
-     * @return array<int, array<string, mixed>>
+     * @return array<int, PayPalShippingOption>
      */
     private function withExactlyOneSelected(array $options): array
     {
-        if ([] === $options || in_array(true, array_column($options, 'selected'), true)) {
+        if ([] === $options) {
             return $options;
+        }
+
+        foreach ($options as $option) {
+            if ($option->isSelected()) {
+                return $options;
+            }
         }
 
         $cheapest = array_key_first($options);
         foreach ($options as $index => $option) {
-            if ((float) $option['amount']['value'] < (float) $options[$cheapest]['amount']['value']) {
+            if ($option->amount() < $options[$cheapest]->amount()) {
                 $cheapest = $index;
             }
         }
 
-        $options[$cheapest]['selected'] = true;
+        $options[$cheapest] = $options[$cheapest]->withSelected(true);
 
         return $options;
     }

--- a/src/Resolver/PayPalShippingOptionsResolver.php
+++ b/src/Resolver/PayPalShippingOptionsResolver.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PayPalPlugin\Resolver;
+
+use Sylius\Component\Core\Model\AddressInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\ShipmentInterface;
+use Sylius\Component\Shipping\Calculator\DelegatingCalculatorInterface;
+use Sylius\Component\Shipping\Model\ShippingMethodInterface;
+use Sylius\Component\Shipping\Resolver\ShippingMethodsResolverInterface;
+
+final readonly class PayPalShippingOptionsResolver implements PayPalShippingOptionsResolverInterface
+{
+    private const TYPE_SHIPPING = 'SHIPPING';
+
+    public function __construct(
+        private ShippingMethodsResolverInterface $shippingMethodsResolver,
+        private DelegatingCalculatorInterface $shippingCalculator,
+    ) {
+    }
+
+    public function resolve(OrderInterface $order, AddressInterface $shippingAddress): array
+    {
+        $shipment = $order->getShipments()->first();
+        if (!$shipment instanceof ShipmentInterface) {
+            return [];
+        }
+
+        $originalShippingAddress = $order->getShippingAddress();
+        $originalMethod = $shipment->getMethod();
+        $order->setShippingAddress($shippingAddress);
+
+        try {
+            $options = [];
+
+            foreach ($this->shippingMethodsResolver->getSupportedMethods($shipment) as $method) {
+                $options[] = $this->buildOption($order, $shipment, $method, $originalMethod);
+            }
+        } finally {
+            $shipment->setMethod($originalMethod);
+            $order->setShippingAddress($originalShippingAddress);
+        }
+
+        return $this->withExactlyOneSelected($options);
+    }
+
+    /** @return array<string, mixed> */
+    private function buildOption(
+        OrderInterface $order,
+        ShipmentInterface $shipment,
+        ShippingMethodInterface $method,
+        ?ShippingMethodInterface $currentMethod,
+    ): array {
+        $shipment->setMethod($method);
+
+        return [
+            'id' => (string) $method->getCode(),
+            'amount' => [
+                'currency_code' => (string) $order->getCurrencyCode(),
+                'value' => number_format($this->shippingCalculator->calculate($shipment) / 100, 2, '.', ''),
+            ],
+            'type' => self::TYPE_SHIPPING,
+            'label' => (string) $method->getName(),
+            'selected' => $method === $currentMethod,
+        ];
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $options
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function withExactlyOneSelected(array $options): array
+    {
+        if ([] === $options || in_array(true, array_column($options, 'selected'), true)) {
+            return $options;
+        }
+
+        $cheapest = array_key_first($options);
+        foreach ($options as $index => $option) {
+            if ((float) $option['amount']['value'] < (float) $options[$cheapest]['amount']['value']) {
+                $cheapest = $index;
+            }
+        }
+
+        $options[$cheapest]['selected'] = true;
+
+        return $options;
+    }
+}

--- a/src/Resolver/PayPalShippingOptionsResolverInterface.php
+++ b/src/Resolver/PayPalShippingOptionsResolverInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PayPalPlugin\Resolver;
+
+use Sylius\Component\Core\Model\AddressInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+
+interface PayPalShippingOptionsResolverInterface
+{
+    /** @return array<int, array<string, mixed>> */
+    public function resolve(OrderInterface $order, AddressInterface $shippingAddress): array;
+}

--- a/src/Resolver/PayPalShippingOptionsResolverInterface.php
+++ b/src/Resolver/PayPalShippingOptionsResolverInterface.php
@@ -15,9 +15,10 @@ namespace Sylius\PayPalPlugin\Resolver;
 
 use Sylius\Component\Core\Model\AddressInterface;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\PayPalPlugin\Model\PayPalShippingOption;
 
 interface PayPalShippingOptionsResolverInterface
 {
-    /** @return array<int, array<string, mixed>> */
+    /** @return array<int, PayPalShippingOption> */
     public function resolve(OrderInterface $order, AddressInterface $shippingAddress): array;
 }

--- a/templates/pay_from_cart_page.html.twig
+++ b/templates/pay_from_cart_page.html.twig
@@ -4,8 +4,6 @@
         instanceConfig: webSdkInstanceConfig,
         currencyCode: currency,
         createOrderUrl: createPayPalOrderFromCartUrl,
-        updateOrderUrl: path('sylius_paypal_shop_update_paypal_order'),
-        availableCountries: available_countries,
         captureOrderUrl: processPayPalOrderUrl,
         cancelOrderUrl: path('sylius_paypal_shop_cancel_order'),
         errorUrl: errorPayPalPaymentUrl,

--- a/templates/pay_from_product_page.html.twig
+++ b/templates/pay_from_product_page.html.twig
@@ -4,8 +4,6 @@
         instanceConfig: webSdkInstanceConfig,
         currencyCode: sylius.currencyCode,
         createOrderUrl: createPayPalOrderFromProductUrl,
-        updateOrderUrl: path('sylius_paypal_shop_update_paypal_order'),
-        availableCountries: available_countries,
         addToCartFormSelector: '[name="sylius_shop_add_to_cart"]',
         captureOrderUrl: processPayPalOrderUrl,
         cancelOrderUrl: path('sylius_paypal_shop_cancel_order'),

--- a/tests/DataFixtures/ORM/resources/shipping.yaml
+++ b/tests/DataFixtures/ORM/resources/shipping.yaml
@@ -1,0 +1,60 @@
+Sylius\Component\Addressing\Model\Country:
+    country_us:
+        code: "US"
+        provinces: ["@province_texas"]
+
+Sylius\Component\Addressing\Model\Province:
+    province_texas:
+        code: "US-TX"
+        name: "Texas"
+        abbreviation: "TX"
+        country: "@country_us"
+
+Sylius\Component\Addressing\Model\Zone:
+    zone_us:
+        code: "US"
+        name: "United States"
+        type: "country"
+        scope: "all"
+        members: ["@zone_member_us"]
+
+Sylius\Component\Addressing\Model\ZoneMember:
+    zone_member_us:
+        code: "US"
+        belongsTo: "@zone_us"
+
+Sylius\Component\Core\Model\ShippingMethod:
+    shipping_method_standard:
+        code: "STANDARD"
+        position: 0
+        enabled: true
+        zone: "@zone_us"
+        channels: ["@channel_web"]
+        calculator: "flat_rate"
+        configuration:
+            WEB:
+                amount: 500
+        currentLocale: "en_US"
+        fallbackLocale: "en_US"
+    shipping_method_express:
+        code: "EXPRESS"
+        position: 1
+        enabled: true
+        zone: "@zone_us"
+        channels: ["@channel_web"]
+        calculator: "flat_rate"
+        configuration:
+            WEB:
+                amount: 2000
+        currentLocale: "en_US"
+        fallbackLocale: "en_US"
+
+Sylius\Component\Shipping\Model\ShippingMethodTranslation:
+    shipping_method_standard_translation:
+        locale: "en_US"
+        name: "Standard shipping"
+        translatable: "@shipping_method_standard"
+    shipping_method_express_translation:
+        locale: "en_US"
+        name: "Express shipping"
+        translatable: "@shipping_method_express"

--- a/tests/Functional/ProcessPayPalOrderActionTest.php
+++ b/tests/Functional/ProcessPayPalOrderActionTest.php
@@ -17,6 +17,7 @@ use ApiTestCase\JsonApiTestCase;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\PayPalPlugin\Payum\Action\StatusAction;
 use Sylius\PayPalPlugin\Processor\PaymentCompleteProcessorInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -25,6 +26,12 @@ use Tests\Sylius\PayPalPlugin\Service\FakeOrderDetailsApi;
 
 final class ProcessPayPalOrderActionTest extends JsonApiTestCase
 {
+    private const ITEMS_TOTAL = 40;
+
+    private const STANDARD_SHIPPING_COST = 500;
+
+    private const EXPRESS_SHIPPING_COST = 2000;
+
     public function test_it_completes_the_order_in_one_call_when_the_buyer_approves_in_the_wallet(): void
     {
         $fixtures = $this->loadFixturesFromFiles(['resources/shop.yaml', 'resources/new_cart.yaml']);
@@ -207,6 +214,154 @@ final class ProcessPayPalOrderActionTest extends JsonApiTestCase
         $content = $this->processPayPalOrder($order->getId());
 
         $this->assertSame($this->generateUrl('sylius_shop_order_thank_you'), $content['return_url']);
+    }
+
+    public function test_it_applies_the_shipping_method_the_buyer_picked_in_the_wallet(): void
+    {
+        $fixtures = $this->loadFixturesFromFiles([
+            'resources/shop.yaml',
+            'resources/shipping.yaml',
+            'resources/new_cart.yaml',
+        ]);
+        /** @var OrderInterface $order */
+        $order = $fixtures['new_cart'];
+
+        $this->mockOrderDetailsApi($this->orderDetails(
+            shippingOptions: [
+                ['id' => 'STANDARD', 'amount' => ['currency_code' => 'USD', 'value' => '5.00'], 'selected' => false],
+                ['id' => 'EXPRESS', 'amount' => ['currency_code' => 'USD', 'value' => '20.00'], 'selected' => true],
+            ],
+            shippingTotal: self::EXPRESS_SHIPPING_COST,
+        ));
+        $this->mockSuccessfulPaymentCompleteProcessor();
+
+        $orderId = $order->getId();
+        $content = $this->processPayPalOrder($orderId);
+        $order = $this->refreshOrder($orderId);
+
+        $shipment = $order->getShipments()->first();
+        $this->assertInstanceOf(ShipmentInterface::class, $shipment);
+
+        $shippingMethod = $shipment->getMethod();
+        $this->assertNotNull($shippingMethod);
+        $this->assertSame('EXPRESS', $shippingMethod->getCode());
+        $this->assertSame(self::EXPRESS_SHIPPING_COST, $order->getShippingTotal());
+        $this->assertSame(self::ITEMS_TOTAL, $order->getItemsTotal());
+        $this->assertSame(self::ITEMS_TOTAL + self::EXPRESS_SHIPPING_COST, $order->getTotal());
+        $this->assertSame($this->generateUrl('sylius_shop_order_thank_you'), $content['return_url']);
+    }
+
+    public function test_it_keeps_the_default_shipping_method_when_the_wallet_sends_no_options(): void
+    {
+        $fixtures = $this->loadFixturesFromFiles([
+            'resources/shop.yaml',
+            'resources/shipping.yaml',
+            'resources/new_cart.yaml',
+        ]);
+        /** @var OrderInterface $order */
+        $order = $fixtures['new_cart'];
+
+        $this->mockOrderDetailsApi($this->orderDetails());
+        $this->mockSuccessfulPaymentCompleteProcessor();
+
+        $orderId = $order->getId();
+        $this->processPayPalOrder($orderId);
+        $order = $this->refreshOrder($orderId);
+
+        $shipment = $order->getShipments()->first();
+        $this->assertInstanceOf(ShipmentInterface::class, $shipment);
+
+        $shippingMethod = $shipment->getMethod();
+        $this->assertNotNull($shippingMethod);
+        $this->assertSame('STANDARD', $shippingMethod->getCode());
+        $this->assertSame(self::STANDARD_SHIPPING_COST, $order->getShippingTotal());
+    }
+
+    public function test_it_stores_the_region_of_the_pay_pal_shipping_address_as_a_province_code(): void
+    {
+        $fixtures = $this->loadFixturesFromFiles([
+            'resources/shop.yaml',
+            'resources/shipping.yaml',
+            'resources/new_cart.yaml',
+        ]);
+        /** @var OrderInterface $order */
+        $order = $fixtures['new_cart'];
+
+        $this->mockOrderDetailsApi($this->orderDetails(adminArea1: 'TX'));
+        $this->mockSuccessfulPaymentCompleteProcessor();
+
+        $orderId = $order->getId();
+        $this->processPayPalOrder($orderId);
+        $order = $this->refreshOrder($orderId);
+
+        $shippingAddress = $order->getShippingAddress();
+        $this->assertNotNull($shippingAddress);
+        $this->assertSame('US-TX', $shippingAddress->getProvinceCode());
+        $this->assertNull($shippingAddress->getProvinceName());
+    }
+
+    public function test_it_keeps_an_unknown_region_as_a_province_name(): void
+    {
+        $fixtures = $this->loadFixturesFromFiles([
+            'resources/shop.yaml',
+            'resources/shipping.yaml',
+            'resources/new_cart.yaml',
+        ]);
+        /** @var OrderInterface $order */
+        $order = $fixtures['new_cart'];
+
+        $this->mockOrderDetailsApi($this->orderDetails(adminArea1: 'Nowhere County'));
+        $this->mockSuccessfulPaymentCompleteProcessor();
+
+        $orderId = $order->getId();
+        $this->processPayPalOrder($orderId);
+        $order = $this->refreshOrder($orderId);
+
+        $shippingAddress = $order->getShippingAddress();
+        $this->assertNotNull($shippingAddress);
+        $this->assertNull($shippingAddress->getProvinceCode());
+        $this->assertSame('Nowhere County', $shippingAddress->getProvinceName());
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $shippingOptions
+     *
+     * @return array<string, mixed>
+     */
+    private function orderDetails(
+        array $shippingOptions = [],
+        ?string $adminArea1 = null,
+        int $shippingTotal = self::STANDARD_SHIPPING_COST,
+    ): array {
+        $address = [
+            'address_line_1' => '1 Star City Plaza',
+            'admin_area_2' => 'Star City',
+            'postal_code' => '10001',
+            'country_code' => 'US',
+        ];
+
+        if (null !== $adminArea1) {
+            $address['admin_area_1'] = $adminArea1;
+        }
+
+        $shipping = ['name' => ['full_name' => 'Oliver Queen'], 'address' => $address];
+
+        if ([] !== $shippingOptions) {
+            $shipping['options'] = $shippingOptions;
+        }
+
+        return [
+            'payer' => [
+                'email_address' => 'oliver.queen@star-city.com',
+                'name' => ['given_name' => 'Oliver', 'surname' => 'Queen'],
+                'phone' => ['phone_number' => ['national_number' => '15551234567']],
+                'address' => ['country_code' => 'US'],
+            ],
+            'purchase_units' => [[
+                'amount' => ['value' => number_format((self::ITEMS_TOTAL + $shippingTotal) / 100, 2, '.', '')],
+                'shipping' => $shipping,
+            ]],
+        ];
     }
 
     /** @return array<string, mixed> */

--- a/tests/Unit/Api/CreateOrderApiTest.php
+++ b/tests/Unit/Api/CreateOrderApiTest.php
@@ -16,7 +16,6 @@ namespace Tests\Sylius\PayPalPlugin\Unit\Api;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Sylius\Component\Core\Model\AddressInterface;
 use Sylius\Component\Core\Model\AdjustmentInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
@@ -25,9 +24,11 @@ use Sylius\Component\Payment\Model\GatewayConfigInterface;
 use Sylius\PayPalPlugin\Api\CreateOrderApi;
 use Sylius\PayPalPlugin\Api\CreateOrderApiInterface;
 use Sylius\PayPalPlugin\Client\PayPalClientInterface;
+use Sylius\PayPalPlugin\Factory\PayPalOrderFactoryInterface;
+use Sylius\PayPalPlugin\Model\PayPalOrder;
+use Sylius\PayPalPlugin\Model\PayPalPurchaseUnit;
 use Sylius\PayPalPlugin\Provider\PaymentReferenceNumberProviderInterface;
 use Sylius\PayPalPlugin\Provider\PayPalItemDataProviderInterface;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 final class CreateOrderApiTest extends TestCase
 {
@@ -37,9 +38,7 @@ final class CreateOrderApiTest extends TestCase
 
     private PayPalItemDataProviderInterface&MockObject $payPalItemDataProvider;
 
-    private UrlGeneratorInterface&MockObject $router;
-
-    private string $shopScheme = 'https';
+    private PayPalOrderFactoryInterface&MockObject $payPalOrderFactory;
 
     private CreateOrderApi $createOrderApi;
 
@@ -49,15 +48,13 @@ final class CreateOrderApiTest extends TestCase
         $this->client = $this->createMock(PayPalClientInterface::class);
         $this->paymentReferenceNumberProvider = $this->createMock(PaymentReferenceNumberProviderInterface::class);
         $this->payPalItemDataProvider = $this->createMock(PayPalItemDataProviderInterface::class);
-        $this->router = $this->createMock(UrlGeneratorInterface::class);
-
-        $this->router->method('generate')->willReturnCallback($this->routeUrl(...));
+        $this->payPalOrderFactory = $this->createMock(PayPalOrderFactoryInterface::class);
 
         $this->createOrderApi = new CreateOrderApi(
             $this->client,
             $this->paymentReferenceNumberProvider,
             $this->payPalItemDataProvider,
-            $this->router,
+            $this->payPalOrderFactory,
         );
     }
 
@@ -68,232 +65,75 @@ final class CreateOrderApiTest extends TestCase
     }
 
     #[Test]
-    public function it_creates_paypal_order_based_on_given_payment(): void
+    public function it_posts_the_order_its_factory_built_for_the_payment(): void
     {
         $payment = $this->createMock(PaymentInterface::class);
         $order = $this->createMock(OrderInterface::class);
-        $paymentMethod = $this->createMock(PaymentMethodInterface::class);
-        $gatewayConfig = $this->createMock(GatewayConfigInterface::class);
-
-        $payment->method('getOrder')->willReturn($order);
-        $payment->method('getAmount')->willReturn(10000);
-        $order->method('getCurrencyCode')->willReturn('PLN');
-        $order->method('getShippingAddress')->willReturn(null);
-        $order->method('getItemsTotal')->willReturn(9000);
-        $order->method('getShippingTotal')->willReturn(1000);
-        $order->method('isShippingRequired')->willReturn(true);
-        $order->method('getOrderPromotionTotal')->willReturn(0);
-        $order->method('getAdjustmentsTotalRecursively')
-            ->with(AdjustmentInterface::ORDER_SHIPPING_PROMOTION_ADJUSTMENT)
-            ->willReturn(0);
-
-        $this->payPalItemDataProvider
-            ->method('provide')
-            ->with($order)
-            ->willReturn([
-                'items' => [
-                    [
-                        'name' => 'PRODUCT_ONE',
-                        'unit_amount' => [
-                            'value' => '90.00',
-                            'currency_code' => 'PLN',
-                        ],
-                        'quantity' => 1,
-                        'tax' => [
-                            'value' => '0.00',
-                            'currency_code' => 'PLN',
-                        ],
-                    ],
-                ],
-                'total_item_value' => '90.00',
-                'total_tax' => '0.00',
-            ]);
-
-        $payment->method('getMethod')->willReturn($paymentMethod);
-        $paymentMethod->method('getGatewayConfig')->willReturn($gatewayConfig);
-
-        $this->paymentReferenceNumberProvider
-            ->method('provide')
-            ->with($payment)
-            ->willReturn('REFERENCE-NUMBER');
-
-        $gatewayConfig->method('getConfig')->willReturn(
-            ['merchant_id' => 'merchant-id', 'sylius_merchant_id' => 'sylius-merchant-id'],
-        );
-
-        $this->client
-            ->expects(self::once())
-            ->method('post')
-            ->with(
-                'v2/checkout/orders',
-                'TOKEN',
-                $this->callback(function (array $data): bool {
-                    return
-                        $data['intent'] === 'CAPTURE' &&
-                        $data['purchase_units'][0]['invoice_id'] === 'REFERENCE-NUMBER' &&
-                        $data['purchase_units'][0]['amount']['value'] === '100.00' &&
-                        $data['purchase_units'][0]['amount']['currency_code'] === 'PLN' &&
-                        $data['purchase_units'][0]['amount']['breakdown']['shipping']['currency_code'] === 'PLN' &&
-                        $data['purchase_units'][0]['amount']['breakdown']['shipping']['value'] === '10.00' &&
-                        $data['purchase_units'][0]['items'][0]['name'] === 'PRODUCT_ONE' &&
-                        $data['purchase_units'][0]['items'][0]['quantity'] === 1 &&
-                        $data['purchase_units'][0]['items'][0]['unit_amount']['value'] === '90.00' &&
-                        $data['purchase_units'][0]['items'][0]['unit_amount']['currency_code'] === 'PLN'
-                    ;
-                }),
-            )
-            ->willReturn(['status' => 'CREATED', 'id' => 123]);
-
-        $result = $this->createOrderApi->create('TOKEN', $payment, 'REFERENCE_ID');
-
-        self::assertEquals(['status' => 'CREATED', 'id' => 123], $result);
-    }
-
-    #[Test]
-    public function it_creates_paypal_order_with_shipping_address_based_on_given_payment(): void
-    {
-        $payment = $this->createMock(PaymentInterface::class);
-        $order = $this->createMock(OrderInterface::class);
-        $paymentMethod = $this->createMock(PaymentMethodInterface::class);
-        $gatewayConfig = $this->createMock(GatewayConfigInterface::class);
-        $shippingAddress = $this->createMock(AddressInterface::class);
-
-        $payment->method('getOrder')->willReturn($order);
-        $payment->method('getAmount')->willReturn(10000);
-        $order->method('getCurrencyCode')->willReturn('PLN');
-        $order->method('getShippingAddress')->willReturn($shippingAddress);
-        $order->method('getItemsTotal')->willReturn(9000);
-        $order->method('getShippingTotal')->willReturn(1000);
-        $order->method('isShippingRequired')->willReturn(true);
-        $order->method('getOrderPromotionTotal')->willReturn(0);
-        $order->method('getAdjustmentsTotalRecursively')
-            ->with(AdjustmentInterface::ORDER_SHIPPING_PROMOTION_ADJUSTMENT)
-            ->willReturn(0);
-
-        $shippingAddress->method('getFullName')->willReturn('Gandalf The Grey');
-        $shippingAddress->method('getStreet')->willReturn('Hobbit St. 123');
-        $shippingAddress->method('getCity')->willReturn('Minas Tirith');
-        $shippingAddress->method('getPostcode')->willReturn('000');
-        $shippingAddress->method('getCountryCode')->willReturn('US');
-
-        $this->payPalItemDataProvider
-            ->method('provide')
-            ->with($order)
-            ->willReturn([
-                'items' => [
-                    [
-                        'name' => 'PRODUCT_ONE',
-                        'unit_amount' => [
-                            'value' => '90.00',
-                            'currency_code' => 'PLN',
-                        ],
-                        'quantity' => 1,
-                        'tax' => [
-                            'value' => '0.00',
-                            'currency_code' => 'PLN',
-                        ],
-                    ],
-                ],
-                'total_item_value' => '90.00',
-                'total_tax' => '0.00',
-            ]);
-
-        $payment->method('getMethod')->willReturn($paymentMethod);
-        $paymentMethod->method('getGatewayConfig')->willReturn($gatewayConfig);
-
-        $this->paymentReferenceNumberProvider
-            ->method('provide')
-            ->with($payment)
-            ->willReturn('REFERENCE-NUMBER');
-
-        $gatewayConfig->method('getConfig')->willReturn(
-            ['merchant_id' => 'merchant-id', 'sylius_merchant_id' => 'sylius-merchant-id'],
-        );
-
-        $this->client
-            ->expects(self::once())
-            ->method('post')
-            ->with(
-                'v2/checkout/orders',
-                'TOKEN',
-                $this->callback(function (array $data): bool {
-                    return
-                        $data['intent'] === 'CAPTURE' &&
-                        $data['purchase_units'][0]['invoice_id'] === 'REFERENCE-NUMBER' &&
-                        $data['purchase_units'][0]['amount']['value'] === '100.00' &&
-                        $data['purchase_units'][0]['amount']['currency_code'] === 'PLN' &&
-                        $data['purchase_units'][0]['shipping']['name']['full_name'] === 'Gandalf The Grey' &&
-                        $data['purchase_units'][0]['shipping']['address']['address_line_1'] === 'Hobbit St. 123' &&
-                        $data['purchase_units'][0]['shipping']['address']['admin_area_2'] === 'Minas Tirith' &&
-                        $data['purchase_units'][0]['shipping']['address']['postal_code'] === '000' &&
-                        $data['purchase_units'][0]['shipping']['address']['country_code'] === 'US' &&
-                        $data['purchase_units'][0]['items'][0]['name'] === 'PRODUCT_ONE' &&
-                        $data['purchase_units'][0]['items'][0]['quantity'] === 1 &&
-                        $data['purchase_units'][0]['items'][0]['unit_amount']['value'] === '90.00' &&
-                        $data['purchase_units'][0]['items'][0]['unit_amount']['currency_code'] === 'PLN'
-                    ;
-                }),
-            )
-            ->willReturn(['status' => 'CREATED', 'id' => 123]);
-
-        $result = $this->createOrderApi->create('TOKEN', $payment, 'REFERENCE_ID');
-
-        self::assertEquals(['status' => 'CREATED', 'id' => 123], $result);
-    }
-
-    #[Test]
-    public function it_allows_to_create_digital_order(): void
-    {
-        $payment = $this->createMock(PaymentInterface::class);
-        $order = $this->createMock(OrderInterface::class);
-        $paymentMethod = $this->createMock(PaymentMethodInterface::class);
-        $gatewayConfig = $this->createMock(GatewayConfigInterface::class);
-
-        $payment->method('getOrder')->willReturn($order);
-        $payment->method('getAmount')->willReturn(20000);
-        $order->method('getCurrencyCode')->willReturn('PLN');
-        $order->method('getShippingAddress')->willReturn(null);
-        $order->method('getItemsTotal')->willReturn(20000);
-        $order->method('getShippingTotal')->willReturn(0);
         $order->method('isShippingRequired')->willReturn(false);
+
+        $this->payPalOrderFactory
+            ->expects(self::once())
+            ->method('create')
+            ->with($payment, 'REFERENCE_ID')
+            ->willReturn($payPalOrder = new PayPalOrder(
+                $order,
+                $this->purchaseUnit(),
+                PayPalOrder::INTENT_CAPTURE,
+            ))
+        ;
+
+        $this->client
+            ->expects(self::once())
+            ->method('post')
+            ->with('v2/checkout/orders', 'TOKEN', $payPalOrder->toArray())
+            ->willReturn(['status' => 'CREATED', 'id' => 123])
+        ;
+
+        self::assertSame(
+            ['status' => 'CREATED', 'id' => 123],
+            $this->createOrderApi->create('TOKEN', $payment, 'REFERENCE_ID'),
+        );
+    }
+
+    #[Test]
+    public function it_still_creates_an_order_when_it_is_given_no_factory(): void
+    {
+        $createOrderApi = new CreateOrderApi(
+            $this->client,
+            $this->paymentReferenceNumberProvider,
+            $this->payPalItemDataProvider,
+        );
+
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getCurrencyCode')->willReturn('PLN');
+        $order->method('getShippingTotal')->willReturn(1000);
+        $order->method('isShippingRequired')->willReturn(true);
+        $order->method('getShippingAddress')->willReturn(null);
         $order->method('getOrderPromotionTotal')->willReturn(0);
-        $order->method('getAdjustmentsTotalRecursively')
+        $order
+            ->method('getAdjustmentsTotalRecursively')
             ->with(AdjustmentInterface::ORDER_SHIPPING_PROMOTION_ADJUSTMENT)
-            ->willReturn(0);
+            ->willReturn(0)
+        ;
 
-        $this->payPalItemDataProvider
-            ->method('provide')
-            ->with($order)
-            ->willReturn([
-                'items' => [
-                    [
-                        'name' => 'PRODUCT_ONE',
-                        'unit_amount' => [
-                            'value' => '200.00',
-                            'currency_code' => 'PLN',
-                        ],
-                        'quantity' => 1,
-                        'tax' => [
-                            'value' => '0.00',
-                            'currency_code' => 'PLN',
-                        ],
-                    ],
-                ],
-                'total_item_value' => '200.00',
-                'total_tax' => '0.00',
-            ]);
-
-        $payment->method('getMethod')->willReturn($paymentMethod);
-        $paymentMethod->method('getGatewayConfig')->willReturn($gatewayConfig);
-
+        $gatewayConfig = $this->createMock(GatewayConfigInterface::class);
         $gatewayConfig->method('getConfig')->willReturn(
             ['merchant_id' => 'merchant-id', 'sylius_merchant_id' => 'sylius-merchant-id'],
         );
+        $paymentMethod = $this->createMock(PaymentMethodInterface::class);
+        $paymentMethod->method('getGatewayConfig')->willReturn($gatewayConfig);
 
-        $this->paymentReferenceNumberProvider
-            ->method('provide')
-            ->with($payment)
-            ->willReturn('REFERENCE-NUMBER');
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->method('getOrder')->willReturn($order);
+        $payment->method('getMethod')->willReturn($paymentMethod);
+        $payment->method('getAmount')->willReturn(10000);
+
+        $this->paymentReferenceNumberProvider->method('provide')->willReturn('REFERENCE-NUMBER');
+        $this->payPalItemDataProvider->method('provide')->willReturn([
+            'items' => [],
+            'total_item_value' => '90.00',
+            'total_tax' => '0.00',
+        ]);
 
         $this->client
             ->expects(self::once())
@@ -303,183 +143,37 @@ final class CreateOrderApiTest extends TestCase
                 'TOKEN',
                 $this->callback(function (array $data): bool {
                     return
-                        $data['intent'] === 'CAPTURE' &&
-                        $data['purchase_units'][0]['amount']['value'] === '200.00' &&
-                        $data['purchase_units'][0]['amount']['currency_code'] === 'PLN' &&
-                        $data['application_context']['shipping_preference'] === 'NO_SHIPPING'
+                        'CAPTURE' === $data['intent'] &&
+                        'REFERENCE-NUMBER' === $data['purchase_units'][0]['invoice_id'] &&
+                        '100.00' === $data['purchase_units'][0]['amount']['value'] &&
+                        !array_key_exists('return_url', $data['payment_source']['paypal']['experience_context']) &&
+                        !array_key_exists(
+                            'order_update_callback_config',
+                            $data['payment_source']['paypal']['experience_context'],
+                        )
                     ;
                 }),
             )
-            ->willReturn(['status' => 'CREATED', 'id' => 123]);
+            ->willReturn(['status' => 'PAYER_ACTION_REQUIRED', 'id' => 123])
+        ;
 
-        $result = $this->createOrderApi->create('TOKEN', $payment, 'REFERENCE_ID');
-
-        self::assertEquals(['status' => 'CREATED', 'id' => 123], $result);
+        $createOrderApi->create('TOKEN', $payment, 'REFERENCE_ID');
     }
 
-    #[Test]
-    public function it_sends_the_same_return_and_cancel_url_on_orders_addressed_in_the_wallet(): void
+    private function purchaseUnit(): PayPalPurchaseUnit
     {
-        $payment = $this->createMock(PaymentInterface::class);
-        $order = $this->createMock(OrderInterface::class);
-        $paymentMethod = $this->createMock(PaymentMethodInterface::class);
-        $gatewayConfig = $this->createMock(GatewayConfigInterface::class);
-
-        $payment->method('getOrder')->willReturn($order);
-        $payment->method('getAmount')->willReturn(10000);
-        $payment->method('getMethod')->willReturn($paymentMethod);
-        $order->method('getCurrencyCode')->willReturn('PLN');
-        $order->method('getShippingAddress')->willReturn(null);
-        $order->method('getShippingTotal')->willReturn(1000);
-        $order->method('isShippingRequired')->willReturn(true);
-        $order->method('getOrderPromotionTotal')->willReturn(0);
-        $order->method('getAdjustmentsTotalRecursively')->willReturn(0);
-        $paymentMethod->method('getGatewayConfig')->willReturn($gatewayConfig);
-        $gatewayConfig->method('getConfig')->willReturn(
-            ['merchant_id' => 'merchant-id', 'sylius_merchant_id' => 'sylius-merchant-id'],
+        return new PayPalPurchaseUnit(
+            'REFERENCE_ID',
+            'REFERENCE-NUMBER',
+            'PLN',
+            10000,
+            0,
+            100.00,
+            0.00,
+            0,
+            'merchant-id',
+            [],
+            false,
         );
-
-        $this->payPalItemDataProvider->method('provide')->willReturn([
-            'items' => [],
-            'total_item_value' => '90.00',
-            'total_tax' => '0.00',
-        ]);
-        $this->paymentReferenceNumberProvider->method('provide')->willReturn('REFERENCE-NUMBER');
-
-        $this->client
-            ->expects(self::once())
-            ->method('post')
-            ->with(
-                'v2/checkout/orders',
-                'TOKEN',
-                $this->callback(function (array $data): bool {
-                    return $data['payment_source']['paypal']['experience_context'] === [
-                        'shipping_preference' => 'GET_FROM_FILE',
-                        'user_action' => 'PAY_NOW',
-                        'return_url' => 'https://shop.example.com/checkout/complete',
-                        'cancel_url' => 'https://shop.example.com/checkout/complete',
-                        'order_update_callback_config' => [
-                            'callback_events' => ['SHIPPING_ADDRESS'],
-                            'callback_url' => 'https://shop.example.com/pay-pal-order-shipping-callback',
-                        ],
-                    ];
-                }),
-            )
-            ->willReturn(['status' => 'PAYER_ACTION_REQUIRED', 'id' => 123]);
-
-        $this->createOrderApi->create('TOKEN', $payment, 'REFERENCE_ID');
-    }
-
-    #[Test]
-    public function it_does_not_select_a_payment_source_on_orders_that_already_carry_an_address(): void
-    {
-        $payment = $this->createMock(PaymentInterface::class);
-        $order = $this->createMock(OrderInterface::class);
-        $paymentMethod = $this->createMock(PaymentMethodInterface::class);
-        $gatewayConfig = $this->createMock(GatewayConfigInterface::class);
-        $shippingAddress = $this->createMock(AddressInterface::class);
-
-        $payment->method('getOrder')->willReturn($order);
-        $payment->method('getAmount')->willReturn(10000);
-        $payment->method('getMethod')->willReturn($paymentMethod);
-        $order->method('getCurrencyCode')->willReturn('PLN');
-        $order->method('getShippingAddress')->willReturn($shippingAddress);
-        $order->method('getShippingTotal')->willReturn(1000);
-        $order->method('isShippingRequired')->willReturn(true);
-        $order->method('getOrderPromotionTotal')->willReturn(0);
-        $order->method('getAdjustmentsTotalRecursively')->willReturn(0);
-        $paymentMethod->method('getGatewayConfig')->willReturn($gatewayConfig);
-        $gatewayConfig->method('getConfig')->willReturn(
-            ['merchant_id' => 'merchant-id', 'sylius_merchant_id' => 'sylius-merchant-id'],
-        );
-
-        $this->payPalItemDataProvider->method('provide')->willReturn([
-            'items' => [],
-            'total_item_value' => '90.00',
-            'total_tax' => '0.00',
-        ]);
-        $this->paymentReferenceNumberProvider->method('provide')->willReturn('REFERENCE-NUMBER');
-
-        $this->client
-            ->expects(self::once())
-            ->method('post')
-            ->with(
-                'v2/checkout/orders',
-                'TOKEN',
-                $this->callback(fn (array $data): bool => !array_key_exists('payment_source', $data)),
-            )
-            ->willReturn(['status' => 'CREATED', 'id' => 123]);
-
-        $this->createOrderApi->create('TOKEN', $payment, 'REFERENCE_ID');
-    }
-
-    #[Test]
-    public function it_does_not_declare_a_shipping_callback_paypal_could_not_reach(): void
-    {
-        $this->shopScheme = 'http';
-
-        $payment = $this->walletAddressedPayment();
-
-        $this->client
-            ->expects(self::once())
-            ->method('post')
-            ->with(
-                'v2/checkout/orders',
-                'TOKEN',
-                $this->callback(function (array $data): bool {
-                    $experienceContext = $data['payment_source']['paypal']['experience_context'];
-
-                    // return_url stays: it is a browser redirect the buyer can follow on a local shop,
-                    // unlike the callback PayPal has to reach from its own network.
-                    return
-                        !array_key_exists('order_update_callback_config', $experienceContext) &&
-                        $experienceContext['return_url'] === 'http://shop.example.com/checkout/complete'
-                    ;
-                }),
-            )
-            ->willReturn(['status' => 'PAYER_ACTION_REQUIRED', 'id' => 123]);
-
-        $this->createOrderApi->create('TOKEN', $payment, 'REFERENCE_ID');
-    }
-
-    private function walletAddressedPayment(): PaymentInterface&MockObject
-    {
-        $payment = $this->createMock(PaymentInterface::class);
-        $order = $this->createMock(OrderInterface::class);
-        $paymentMethod = $this->createMock(PaymentMethodInterface::class);
-        $gatewayConfig = $this->createMock(GatewayConfigInterface::class);
-
-        $payment->method('getOrder')->willReturn($order);
-        $payment->method('getAmount')->willReturn(10000);
-        $payment->method('getMethod')->willReturn($paymentMethod);
-        $order->method('getCurrencyCode')->willReturn('PLN');
-        $order->method('getShippingAddress')->willReturn(null);
-        $order->method('getShippingTotal')->willReturn(1000);
-        $order->method('isShippingRequired')->willReturn(true);
-        $order->method('getOrderPromotionTotal')->willReturn(0);
-        $order->method('getAdjustmentsTotalRecursively')->willReturn(0);
-        $paymentMethod->method('getGatewayConfig')->willReturn($gatewayConfig);
-        $gatewayConfig->method('getConfig')->willReturn(
-            ['merchant_id' => 'merchant-id', 'sylius_merchant_id' => 'sylius-merchant-id'],
-        );
-
-        $this->payPalItemDataProvider->method('provide')->willReturn([
-            'items' => [],
-            'total_item_value' => '90.00',
-            'total_tax' => '0.00',
-        ]);
-        $this->paymentReferenceNumberProvider->method('provide')->willReturn('REFERENCE-NUMBER');
-
-        return $payment;
-    }
-
-    private function routeUrl(string $route): string
-    {
-        $path = match ($route) {
-            'sylius_shop_checkout_complete' => '/checkout/complete',
-            'sylius_paypal_shop_order_shipping_callback' => '/pay-pal-order-shipping-callback',
-        };
-
-        return $this->shopScheme . '://shop.example.com' . $path;
     }
 }

--- a/tests/Unit/Api/CreateOrderApiTest.php
+++ b/tests/Unit/Api/CreateOrderApiTest.php
@@ -39,6 +39,8 @@ final class CreateOrderApiTest extends TestCase
 
     private UrlGeneratorInterface&MockObject $router;
 
+    private string $shopScheme = 'https';
+
     private CreateOrderApi $createOrderApi;
 
     protected function setUp(): void
@@ -49,10 +51,7 @@ final class CreateOrderApiTest extends TestCase
         $this->payPalItemDataProvider = $this->createMock(PayPalItemDataProviderInterface::class);
         $this->router = $this->createMock(UrlGeneratorInterface::class);
 
-        $this->router
-            ->method('generate')
-            ->with('sylius_shop_checkout_complete', [], UrlGeneratorInterface::ABSOLUTE_URL)
-            ->willReturn('https://shop.example.com/checkout/complete');
+        $this->router->method('generate')->willReturnCallback($this->routeUrl(...));
 
         $this->createOrderApi = new CreateOrderApi(
             $this->client,
@@ -359,6 +358,10 @@ final class CreateOrderApiTest extends TestCase
                         'user_action' => 'PAY_NOW',
                         'return_url' => 'https://shop.example.com/checkout/complete',
                         'cancel_url' => 'https://shop.example.com/checkout/complete',
+                        'order_update_callback_config' => [
+                            'callback_events' => ['SHIPPING_ADDRESS'],
+                            'callback_url' => 'https://shop.example.com/pay-pal-order-shipping-callback',
+                        ],
                     ];
                 }),
             )
@@ -408,5 +411,75 @@ final class CreateOrderApiTest extends TestCase
             ->willReturn(['status' => 'CREATED', 'id' => 123]);
 
         $this->createOrderApi->create('TOKEN', $payment, 'REFERENCE_ID');
+    }
+
+    #[Test]
+    public function it_does_not_declare_a_shipping_callback_paypal_could_not_reach(): void
+    {
+        $this->shopScheme = 'http';
+
+        $payment = $this->walletAddressedPayment();
+
+        $this->client
+            ->expects(self::once())
+            ->method('post')
+            ->with(
+                'v2/checkout/orders',
+                'TOKEN',
+                $this->callback(function (array $data): bool {
+                    $experienceContext = $data['payment_source']['paypal']['experience_context'];
+
+                    // return_url stays: it is a browser redirect the buyer can follow on a local shop,
+                    // unlike the callback PayPal has to reach from its own network.
+                    return
+                        !array_key_exists('order_update_callback_config', $experienceContext) &&
+                        $experienceContext['return_url'] === 'http://shop.example.com/checkout/complete'
+                    ;
+                }),
+            )
+            ->willReturn(['status' => 'PAYER_ACTION_REQUIRED', 'id' => 123]);
+
+        $this->createOrderApi->create('TOKEN', $payment, 'REFERENCE_ID');
+    }
+
+    private function walletAddressedPayment(): PaymentInterface&MockObject
+    {
+        $payment = $this->createMock(PaymentInterface::class);
+        $order = $this->createMock(OrderInterface::class);
+        $paymentMethod = $this->createMock(PaymentMethodInterface::class);
+        $gatewayConfig = $this->createMock(GatewayConfigInterface::class);
+
+        $payment->method('getOrder')->willReturn($order);
+        $payment->method('getAmount')->willReturn(10000);
+        $payment->method('getMethod')->willReturn($paymentMethod);
+        $order->method('getCurrencyCode')->willReturn('PLN');
+        $order->method('getShippingAddress')->willReturn(null);
+        $order->method('getShippingTotal')->willReturn(1000);
+        $order->method('isShippingRequired')->willReturn(true);
+        $order->method('getOrderPromotionTotal')->willReturn(0);
+        $order->method('getAdjustmentsTotalRecursively')->willReturn(0);
+        $paymentMethod->method('getGatewayConfig')->willReturn($gatewayConfig);
+        $gatewayConfig->method('getConfig')->willReturn(
+            ['merchant_id' => 'merchant-id', 'sylius_merchant_id' => 'sylius-merchant-id'],
+        );
+
+        $this->payPalItemDataProvider->method('provide')->willReturn([
+            'items' => [],
+            'total_item_value' => '90.00',
+            'total_tax' => '0.00',
+        ]);
+        $this->paymentReferenceNumberProvider->method('provide')->willReturn('REFERENCE-NUMBER');
+
+        return $payment;
+    }
+
+    private function routeUrl(string $route): string
+    {
+        $path = match ($route) {
+            'sylius_shop_checkout_complete' => '/checkout/complete',
+            'sylius_paypal_shop_order_shipping_callback' => '/pay-pal-order-shipping-callback',
+        };
+
+        return $this->shopScheme . '://shop.example.com' . $path;
     }
 }

--- a/tests/Unit/Api/CreateOrderApiTest.php
+++ b/tests/Unit/Api/CreateOrderApiTest.php
@@ -27,6 +27,7 @@ use Sylius\PayPalPlugin\Api\CreateOrderApiInterface;
 use Sylius\PayPalPlugin\Client\PayPalClientInterface;
 use Sylius\PayPalPlugin\Provider\PaymentReferenceNumberProviderInterface;
 use Sylius\PayPalPlugin\Provider\PayPalItemDataProviderInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 final class CreateOrderApiTest extends TestCase
 {
@@ -36,6 +37,8 @@ final class CreateOrderApiTest extends TestCase
 
     private PayPalItemDataProviderInterface&MockObject $payPalItemDataProvider;
 
+    private UrlGeneratorInterface&MockObject $router;
+
     private CreateOrderApi $createOrderApi;
 
     protected function setUp(): void
@@ -44,11 +47,18 @@ final class CreateOrderApiTest extends TestCase
         $this->client = $this->createMock(PayPalClientInterface::class);
         $this->paymentReferenceNumberProvider = $this->createMock(PaymentReferenceNumberProviderInterface::class);
         $this->payPalItemDataProvider = $this->createMock(PayPalItemDataProviderInterface::class);
+        $this->router = $this->createMock(UrlGeneratorInterface::class);
+
+        $this->router
+            ->method('generate')
+            ->with('sylius_shop_checkout_complete', [], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('https://shop.example.com/checkout/complete');
 
         $this->createOrderApi = new CreateOrderApi(
             $this->client,
             $this->paymentReferenceNumberProvider,
             $this->payPalItemDataProvider,
+            $this->router,
         );
     }
 
@@ -306,5 +316,97 @@ final class CreateOrderApiTest extends TestCase
         $result = $this->createOrderApi->create('TOKEN', $payment, 'REFERENCE_ID');
 
         self::assertEquals(['status' => 'CREATED', 'id' => 123], $result);
+    }
+
+    #[Test]
+    public function it_sends_the_same_return_and_cancel_url_on_orders_addressed_in_the_wallet(): void
+    {
+        $payment = $this->createMock(PaymentInterface::class);
+        $order = $this->createMock(OrderInterface::class);
+        $paymentMethod = $this->createMock(PaymentMethodInterface::class);
+        $gatewayConfig = $this->createMock(GatewayConfigInterface::class);
+
+        $payment->method('getOrder')->willReturn($order);
+        $payment->method('getAmount')->willReturn(10000);
+        $payment->method('getMethod')->willReturn($paymentMethod);
+        $order->method('getCurrencyCode')->willReturn('PLN');
+        $order->method('getShippingAddress')->willReturn(null);
+        $order->method('getShippingTotal')->willReturn(1000);
+        $order->method('isShippingRequired')->willReturn(true);
+        $order->method('getOrderPromotionTotal')->willReturn(0);
+        $order->method('getAdjustmentsTotalRecursively')->willReturn(0);
+        $paymentMethod->method('getGatewayConfig')->willReturn($gatewayConfig);
+        $gatewayConfig->method('getConfig')->willReturn(
+            ['merchant_id' => 'merchant-id', 'sylius_merchant_id' => 'sylius-merchant-id'],
+        );
+
+        $this->payPalItemDataProvider->method('provide')->willReturn([
+            'items' => [],
+            'total_item_value' => '90.00',
+            'total_tax' => '0.00',
+        ]);
+        $this->paymentReferenceNumberProvider->method('provide')->willReturn('REFERENCE-NUMBER');
+
+        $this->client
+            ->expects(self::once())
+            ->method('post')
+            ->with(
+                'v2/checkout/orders',
+                'TOKEN',
+                $this->callback(function (array $data): bool {
+                    return $data['payment_source']['paypal']['experience_context'] === [
+                        'shipping_preference' => 'GET_FROM_FILE',
+                        'user_action' => 'PAY_NOW',
+                        'return_url' => 'https://shop.example.com/checkout/complete',
+                        'cancel_url' => 'https://shop.example.com/checkout/complete',
+                    ];
+                }),
+            )
+            ->willReturn(['status' => 'PAYER_ACTION_REQUIRED', 'id' => 123]);
+
+        $this->createOrderApi->create('TOKEN', $payment, 'REFERENCE_ID');
+    }
+
+    #[Test]
+    public function it_does_not_select_a_payment_source_on_orders_that_already_carry_an_address(): void
+    {
+        $payment = $this->createMock(PaymentInterface::class);
+        $order = $this->createMock(OrderInterface::class);
+        $paymentMethod = $this->createMock(PaymentMethodInterface::class);
+        $gatewayConfig = $this->createMock(GatewayConfigInterface::class);
+        $shippingAddress = $this->createMock(AddressInterface::class);
+
+        $payment->method('getOrder')->willReturn($order);
+        $payment->method('getAmount')->willReturn(10000);
+        $payment->method('getMethod')->willReturn($paymentMethod);
+        $order->method('getCurrencyCode')->willReturn('PLN');
+        $order->method('getShippingAddress')->willReturn($shippingAddress);
+        $order->method('getShippingTotal')->willReturn(1000);
+        $order->method('isShippingRequired')->willReturn(true);
+        $order->method('getOrderPromotionTotal')->willReturn(0);
+        $order->method('getAdjustmentsTotalRecursively')->willReturn(0);
+        $paymentMethod->method('getGatewayConfig')->willReturn($gatewayConfig);
+        $gatewayConfig->method('getConfig')->willReturn(
+            ['merchant_id' => 'merchant-id', 'sylius_merchant_id' => 'sylius-merchant-id'],
+        );
+
+        $this->payPalItemDataProvider->method('provide')->willReturn([
+            'items' => [],
+            'total_item_value' => '90.00',
+            'total_tax' => '0.00',
+        ]);
+        $this->paymentReferenceNumberProvider->method('provide')->willReturn('REFERENCE-NUMBER');
+
+        $this->client
+            ->expects(self::once())
+            ->method('post')
+            ->with(
+                'v2/checkout/orders',
+                'TOKEN',
+                $this->callback(fn (array $data): bool => !array_key_exists('payment_source', $data)),
+            )
+            ->willReturn(['status' => 'CREATED', 'id' => 123]);
+
+        $this->createOrderApi->create('TOKEN', $payment, 'REFERENCE_ID');
     }
 }

--- a/tests/Unit/Api/UpdateOrderApiTest.php
+++ b/tests/Unit/Api/UpdateOrderApiTest.php
@@ -23,6 +23,7 @@ use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\PayPalPlugin\Api\UpdateOrderApi;
 use Sylius\PayPalPlugin\Api\UpdateOrderApiInterface;
 use Sylius\PayPalPlugin\Client\PayPalClientInterface;
+use Sylius\PayPalPlugin\Factory\PayPalPurchaseUnitFactory;
 use Sylius\PayPalPlugin\Provider\PaymentReferenceNumberProviderInterface;
 use Sylius\PayPalPlugin\Provider\PayPalItemDataProviderInterface;
 
@@ -47,6 +48,7 @@ final class UpdateOrderApiTest extends TestCase
             $this->client,
             $this->paymentReferenceNumberProvider,
             $this->payPalItemsDataProvider,
+            new PayPalPurchaseUnitFactory($this->paymentReferenceNumberProvider, $this->payPalItemsDataProvider),
         );
     }
 

--- a/tests/Unit/Controller/PayPalOrderShippingCallbackActionTest.php
+++ b/tests/Unit/Controller/PayPalOrderShippingCallbackActionTest.php
@@ -21,9 +21,9 @@ use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\PayPalPlugin\Controller\PayPalOrderShippingCallbackAction;
 use Sylius\PayPalPlugin\Exception\PaymentNotFoundException;
+use Sylius\PayPalPlugin\Factory\PayPalShippingAddressFactoryInterface;
 use Sylius\PayPalPlugin\Provider\ChannelAvailableCountriesProviderInterface;
 use Sylius\PayPalPlugin\Repository\Query\PaypalPaymentQueryInterface;
-use Sylius\PayPalPlugin\Resolver\PayPalShippingAddressResolverInterface;
 use Sylius\PayPalPlugin\Resolver\PayPalShippingOptionsResolverInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -58,7 +58,7 @@ final class PayPalOrderShippingCallbackActionTest extends TestCase
 
     private ChannelAvailableCountriesProviderInterface&MockObject $availableCountriesProvider;
 
-    private PayPalShippingAddressResolverInterface&MockObject $shippingAddressResolver;
+    private PayPalShippingAddressFactoryInterface&MockObject $shippingAddressFactory;
 
     private PayPalShippingOptionsResolverInterface&MockObject $shippingOptionsResolver;
 
@@ -71,7 +71,7 @@ final class PayPalOrderShippingCallbackActionTest extends TestCase
         parent::setUp();
         $this->paypalPaymentQuery = $this->createMock(PaypalPaymentQueryInterface::class);
         $this->availableCountriesProvider = $this->createMock(ChannelAvailableCountriesProviderInterface::class);
-        $this->shippingAddressResolver = $this->createMock(PayPalShippingAddressResolverInterface::class);
+        $this->shippingAddressFactory = $this->createMock(PayPalShippingAddressFactoryInterface::class);
         $this->shippingOptionsResolver = $this->createMock(PayPalShippingOptionsResolverInterface::class);
 
         $this->order = $this->createMock(OrderInterface::class);
@@ -86,7 +86,7 @@ final class PayPalOrderShippingCallbackActionTest extends TestCase
         $this->action = new PayPalOrderShippingCallbackAction(
             $this->paypalPaymentQuery,
             $this->availableCountriesProvider,
-            $this->shippingAddressResolver,
+            $this->shippingAddressFactory,
             $this->shippingOptionsResolver,
         );
     }
@@ -94,9 +94,9 @@ final class PayPalOrderShippingCallbackActionTest extends TestCase
     public function test_it_answers_with_the_shipping_options_and_the_cost_of_the_selected_one(): void
     {
         $this->availableCountriesProvider->method('provideForChannel')->willReturn(['US', 'CA']);
-        $this->shippingAddressResolver
+        $this->shippingAddressFactory
             ->expects(self::once())
-            ->method('resolve')
+            ->method('create')
             ->with(self::SHIPPING_ADDRESS)
             ->willReturn($address = $this->createMock(AddressInterface::class));
         $this->shippingOptionsResolver
@@ -163,7 +163,7 @@ final class PayPalOrderShippingCallbackActionTest extends TestCase
         $action = new PayPalOrderShippingCallbackAction(
             $paypalPaymentQuery,
             $this->availableCountriesProvider,
-            $this->shippingAddressResolver,
+            $this->shippingAddressFactory,
             $this->shippingOptionsResolver,
         );
 

--- a/tests/Unit/Controller/PayPalOrderShippingCallbackActionTest.php
+++ b/tests/Unit/Controller/PayPalOrderShippingCallbackActionTest.php
@@ -91,7 +91,7 @@ final class PayPalOrderShippingCallbackActionTest extends TestCase
         );
     }
 
-    public function test_it_answers_with_the_shipping_options_and_the_amount_paypal_sent(): void
+    public function test_it_answers_with_the_shipping_options_and_the_cost_of_the_selected_one(): void
     {
         $this->availableCountriesProvider->method('provideForChannel')->willReturn(['US', 'CA']);
         $this->shippingAddressResolver
@@ -110,7 +110,19 @@ final class PayPalOrderShippingCallbackActionTest extends TestCase
         self::assertSame(Response::HTTP_OK, $response->getStatusCode());
         self::assertSame([
             'id' => 'PAYPAL_ORDER_ID',
-            'purchase_units' => [self::PURCHASE_UNIT + ['shipping_options' => self::SHIPPING_OPTIONS]],
+            'purchase_units' => [[
+                'reference_id' => 'REFERENCE_ID',
+                'amount' => [
+                    'currency_code' => 'USD',
+                    'value' => '110.00',
+                    'breakdown' => [
+                        'item_total' => ['currency_code' => 'USD', 'value' => '90.00'],
+                        'tax_total' => ['currency_code' => 'USD', 'value' => '10.00'],
+                        'shipping' => ['currency_code' => 'USD', 'value' => '10.00'],
+                    ],
+                ],
+                'shipping_options' => self::SHIPPING_OPTIONS,
+            ]],
         ], json_decode((string) $response->getContent(), true));
     }
 
@@ -183,6 +195,41 @@ final class PayPalOrderShippingCallbackActionTest extends TestCase
         self::assertSame(
             ['name' => 'UNPROCESSABLE_ENTITY', 'details' => [['issue' => $issue]]],
             json_decode((string) $response->getContent(), true),
+        );
+    }
+
+    public function test_it_leaves_an_amount_without_a_breakdown_alone(): void
+    {
+        $this->availableCountriesProvider->method('provideForChannel')->willReturn(['US']);
+        $this->shippingOptionsResolver->method('resolve')->willReturn(self::SHIPPING_OPTIONS);
+
+        $amount = ['currency_code' => 'USD', 'value' => '100.00'];
+        $response = ($this->action)($this->callbackRequest([
+            'purchase_units' => [['reference_id' => 'REFERENCE_ID', 'amount' => $amount]],
+        ]));
+
+        $content = json_decode((string) $response->getContent(), true);
+
+        self::assertSame($amount, $content['purchase_units'][0]['amount']);
+    }
+
+    public function test_it_drops_the_purchase_unit_fields_paypal_does_not_read_back(): void
+    {
+        $this->availableCountriesProvider->method('provideForChannel')->willReturn(['US']);
+        $this->shippingOptionsResolver->method('resolve')->willReturn(self::SHIPPING_OPTIONS);
+
+        $purchaseUnit = self::PURCHASE_UNIT + [
+            'payee' => ['merchant_id' => 'MERCHANT_ID'],
+            'invoice_id' => 'INVOICE_ID',
+            'soft_descriptor' => 'Sylius PayPal Payment',
+        ];
+        $response = ($this->action)($this->callbackRequest(['purchase_units' => [$purchaseUnit]]));
+
+        $content = json_decode((string) $response->getContent(), true);
+
+        self::assertSame(
+            ['reference_id', 'amount', 'shipping_options'],
+            array_keys($content['purchase_units'][0]),
         );
     }
 }

--- a/tests/Unit/Controller/PayPalOrderShippingCallbackActionTest.php
+++ b/tests/Unit/Controller/PayPalOrderShippingCallbackActionTest.php
@@ -1,0 +1,188 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\PayPalPlugin\Unit\Controller;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Core\Model\AddressInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\PayPalPlugin\Controller\PayPalOrderShippingCallbackAction;
+use Sylius\PayPalPlugin\Exception\PaymentNotFoundException;
+use Sylius\PayPalPlugin\Provider\ChannelAvailableCountriesProviderInterface;
+use Sylius\PayPalPlugin\Repository\Query\PaypalPaymentQueryInterface;
+use Sylius\PayPalPlugin\Resolver\PayPalShippingAddressResolverInterface;
+use Sylius\PayPalPlugin\Resolver\PayPalShippingOptionsResolverInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class PayPalOrderShippingCallbackActionTest extends TestCase
+{
+    private const SHIPPING_ADDRESS = [
+        'country_code' => 'US',
+        'admin_area_1' => 'TX',
+        'admin_area_2' => 'Dallas',
+        'postal_code' => '75001',
+    ];
+
+    private const PURCHASE_UNIT = [
+        'reference_id' => 'REFERENCE_ID',
+        'amount' => [
+            'currency_code' => 'USD',
+            'value' => '100.00',
+            'breakdown' => [
+                'item_total' => ['currency_code' => 'USD', 'value' => '90.00'],
+                'tax_total' => ['currency_code' => 'USD', 'value' => '10.00'],
+                'shipping' => ['currency_code' => 'USD', 'value' => '0.00'],
+            ],
+        ],
+    ];
+
+    private const SHIPPING_OPTIONS = [
+        ['id' => 'ups', 'amount' => ['currency_code' => 'USD', 'value' => '10.00'], 'type' => 'SHIPPING', 'label' => 'UPS', 'selected' => true],
+    ];
+
+    private PaypalPaymentQueryInterface&MockObject $paypalPaymentQuery;
+
+    private ChannelAvailableCountriesProviderInterface&MockObject $availableCountriesProvider;
+
+    private PayPalShippingAddressResolverInterface&MockObject $shippingAddressResolver;
+
+    private PayPalShippingOptionsResolverInterface&MockObject $shippingOptionsResolver;
+
+    private OrderInterface&MockObject $order;
+
+    private PayPalOrderShippingCallbackAction $action;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->paypalPaymentQuery = $this->createMock(PaypalPaymentQueryInterface::class);
+        $this->availableCountriesProvider = $this->createMock(ChannelAvailableCountriesProviderInterface::class);
+        $this->shippingAddressResolver = $this->createMock(PayPalShippingAddressResolverInterface::class);
+        $this->shippingOptionsResolver = $this->createMock(PayPalShippingOptionsResolverInterface::class);
+
+        $this->order = $this->createMock(OrderInterface::class);
+        $this->order->method('getChannel')->willReturn($this->createMock(ChannelInterface::class));
+
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->method('getOrder')->willReturn($this->order);
+        $this->paypalPaymentQuery
+            ->method('getForUpdateByOrderId')
+            ->willReturnCallback(fn (string $id): ?PaymentInterface => 'PAYPAL_ORDER_ID' === $id ? $payment : null);
+
+        $this->action = new PayPalOrderShippingCallbackAction(
+            $this->paypalPaymentQuery,
+            $this->availableCountriesProvider,
+            $this->shippingAddressResolver,
+            $this->shippingOptionsResolver,
+        );
+    }
+
+    public function test_it_answers_with_the_shipping_options_and_the_amount_paypal_sent(): void
+    {
+        $this->availableCountriesProvider->method('provideForChannel')->willReturn(['US', 'CA']);
+        $this->shippingAddressResolver
+            ->expects(self::once())
+            ->method('resolve')
+            ->with(self::SHIPPING_ADDRESS)
+            ->willReturn($address = $this->createMock(AddressInterface::class));
+        $this->shippingOptionsResolver
+            ->expects(self::once())
+            ->method('resolve')
+            ->with($this->order, $address)
+            ->willReturn(self::SHIPPING_OPTIONS);
+
+        $response = ($this->action)($this->callbackRequest());
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertSame([
+            'id' => 'PAYPAL_ORDER_ID',
+            'purchase_units' => [self::PURCHASE_UNIT + ['shipping_options' => self::SHIPPING_OPTIONS]],
+        ], json_decode((string) $response->getContent(), true));
+    }
+
+    public function test_it_refuses_a_country_the_channel_does_not_sell_to(): void
+    {
+        $this->availableCountriesProvider->method('provideForChannel')->willReturn(['CA']);
+        $this->shippingOptionsResolver->expects(self::never())->method('resolve');
+
+        $response = ($this->action)($this->callbackRequest());
+
+        self::assertUnprocessableWithIssue('COUNTRY_ERROR', $response);
+    }
+
+    public function test_it_refuses_an_address_nothing_can_be_shipped_to(): void
+    {
+        $this->availableCountriesProvider->method('provideForChannel')->willReturn(['US']);
+        $this->shippingOptionsResolver->method('resolve')->willReturn([]);
+
+        $response = ($this->action)($this->callbackRequest());
+
+        self::assertUnprocessableWithIssue('ADDRESS_ERROR', $response);
+    }
+
+    public function test_it_refuses_an_order_id_it_does_not_know(): void
+    {
+        $this->availableCountriesProvider->expects(self::never())->method('provideForChannel');
+
+        $response = ($this->action)($this->callbackRequest(['id' => 'UNKNOWN']));
+
+        self::assertUnprocessableWithIssue('ADDRESS_ERROR', $response);
+    }
+
+    public function test_it_refuses_an_order_whose_payment_lookup_fails(): void
+    {
+        $paypalPaymentQuery = $this->createMock(PaypalPaymentQueryInterface::class);
+        $paypalPaymentQuery->method('getForUpdateByOrderId')->willThrowException(new PaymentNotFoundException());
+
+        $action = new PayPalOrderShippingCallbackAction(
+            $paypalPaymentQuery,
+            $this->availableCountriesProvider,
+            $this->shippingAddressResolver,
+            $this->shippingOptionsResolver,
+        );
+
+        self::assertUnprocessableWithIssue('ADDRESS_ERROR', ($action)($this->callbackRequest()));
+    }
+
+    public function test_it_refuses_a_body_that_is_not_json(): void
+    {
+        $request = new Request([], [], [], [], [], ['CONTENT_TYPE' => 'application/json'], 'not json');
+
+        self::assertUnprocessableWithIssue('ADDRESS_ERROR', ($this->action)($request));
+    }
+
+    /** @param array<string, mixed> $overrides */
+    private function callbackRequest(array $overrides = []): Request
+    {
+        $payload = $overrides + [
+            'id' => 'PAYPAL_ORDER_ID',
+            'shipping_address' => self::SHIPPING_ADDRESS,
+            'purchase_units' => [self::PURCHASE_UNIT],
+        ];
+
+        return new Request([], [], [], [], [], ['CONTENT_TYPE' => 'application/json'], (string) json_encode($payload));
+    }
+
+    private static function assertUnprocessableWithIssue(string $issue, Response $response): void
+    {
+        self::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        self::assertSame(
+            ['name' => 'UNPROCESSABLE_ENTITY', 'details' => [['issue' => $issue]]],
+            json_decode((string) $response->getContent(), true),
+        );
+    }
+}

--- a/tests/Unit/Controller/PayPalOrderShippingCallbackActionTest.php
+++ b/tests/Unit/Controller/PayPalOrderShippingCallbackActionTest.php
@@ -22,6 +22,7 @@ use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\PayPalPlugin\Controller\PayPalOrderShippingCallbackAction;
 use Sylius\PayPalPlugin\Exception\PaymentNotFoundException;
 use Sylius\PayPalPlugin\Factory\PayPalShippingAddressFactoryInterface;
+use Sylius\PayPalPlugin\Factory\PayPalShippingCallbackResponseFactoryInterface;
 use Sylius\PayPalPlugin\Provider\ChannelAvailableCountriesProviderInterface;
 use Sylius\PayPalPlugin\Repository\Query\PaypalPaymentQueryInterface;
 use Sylius\PayPalPlugin\Resolver\PayPalShippingOptionsResolverInterface;
@@ -62,6 +63,8 @@ final class PayPalOrderShippingCallbackActionTest extends TestCase
 
     private PayPalShippingOptionsResolverInterface&MockObject $shippingOptionsResolver;
 
+    private PayPalShippingCallbackResponseFactoryInterface&MockObject $responseFactory;
+
     private OrderInterface&MockObject $order;
 
     private PayPalOrderShippingCallbackAction $action;
@@ -73,6 +76,7 @@ final class PayPalOrderShippingCallbackActionTest extends TestCase
         $this->availableCountriesProvider = $this->createMock(ChannelAvailableCountriesProviderInterface::class);
         $this->shippingAddressFactory = $this->createMock(PayPalShippingAddressFactoryInterface::class);
         $this->shippingOptionsResolver = $this->createMock(PayPalShippingOptionsResolverInterface::class);
+        $this->responseFactory = $this->createMock(PayPalShippingCallbackResponseFactoryInterface::class);
 
         $this->order = $this->createMock(OrderInterface::class);
         $this->order->method('getChannel')->willReturn($this->createMock(ChannelInterface::class));
@@ -88,10 +92,11 @@ final class PayPalOrderShippingCallbackActionTest extends TestCase
             $this->availableCountriesProvider,
             $this->shippingAddressFactory,
             $this->shippingOptionsResolver,
+            $this->responseFactory,
         );
     }
 
-    public function test_it_answers_with_the_shipping_options_and_the_cost_of_the_selected_one(): void
+    public function test_it_answers_with_the_response_its_factory_built_for_the_resolved_options(): void
     {
         $this->availableCountriesProvider->method('provideForChannel')->willReturn(['US', 'CA']);
         $this->shippingAddressFactory
@@ -104,26 +109,19 @@ final class PayPalOrderShippingCallbackActionTest extends TestCase
             ->method('resolve')
             ->with($this->order, $address)
             ->willReturn(self::SHIPPING_OPTIONS);
+        $this->responseFactory
+            ->expects(self::once())
+            ->method('create')
+            ->with('PAYPAL_ORDER_ID', self::PURCHASE_UNIT, self::SHIPPING_OPTIONS)
+            ->willReturn(['id' => 'PAYPAL_ORDER_ID', 'purchase_units' => ['RESPONSE_UNIT']]);
 
         $response = ($this->action)($this->callbackRequest());
 
         self::assertSame(Response::HTTP_OK, $response->getStatusCode());
-        self::assertSame([
-            'id' => 'PAYPAL_ORDER_ID',
-            'purchase_units' => [[
-                'reference_id' => 'REFERENCE_ID',
-                'amount' => [
-                    'currency_code' => 'USD',
-                    'value' => '110.00',
-                    'breakdown' => [
-                        'item_total' => ['currency_code' => 'USD', 'value' => '90.00'],
-                        'tax_total' => ['currency_code' => 'USD', 'value' => '10.00'],
-                        'shipping' => ['currency_code' => 'USD', 'value' => '10.00'],
-                    ],
-                ],
-                'shipping_options' => self::SHIPPING_OPTIONS,
-            ]],
-        ], json_decode((string) $response->getContent(), true));
+        self::assertSame(
+            ['id' => 'PAYPAL_ORDER_ID', 'purchase_units' => ['RESPONSE_UNIT']],
+            json_decode((string) $response->getContent(), true),
+        );
     }
 
     public function test_it_refuses_a_country_the_channel_does_not_sell_to(): void
@@ -165,6 +163,7 @@ final class PayPalOrderShippingCallbackActionTest extends TestCase
             $this->availableCountriesProvider,
             $this->shippingAddressFactory,
             $this->shippingOptionsResolver,
+            $this->responseFactory,
         );
 
         self::assertUnprocessableWithIssue('ADDRESS_ERROR', ($action)($this->callbackRequest()));
@@ -195,41 +194,6 @@ final class PayPalOrderShippingCallbackActionTest extends TestCase
         self::assertSame(
             ['name' => 'UNPROCESSABLE_ENTITY', 'details' => [['issue' => $issue]]],
             json_decode((string) $response->getContent(), true),
-        );
-    }
-
-    public function test_it_leaves_an_amount_without_a_breakdown_alone(): void
-    {
-        $this->availableCountriesProvider->method('provideForChannel')->willReturn(['US']);
-        $this->shippingOptionsResolver->method('resolve')->willReturn(self::SHIPPING_OPTIONS);
-
-        $amount = ['currency_code' => 'USD', 'value' => '100.00'];
-        $response = ($this->action)($this->callbackRequest([
-            'purchase_units' => [['reference_id' => 'REFERENCE_ID', 'amount' => $amount]],
-        ]));
-
-        $content = json_decode((string) $response->getContent(), true);
-
-        self::assertSame($amount, $content['purchase_units'][0]['amount']);
-    }
-
-    public function test_it_drops_the_purchase_unit_fields_paypal_does_not_read_back(): void
-    {
-        $this->availableCountriesProvider->method('provideForChannel')->willReturn(['US']);
-        $this->shippingOptionsResolver->method('resolve')->willReturn(self::SHIPPING_OPTIONS);
-
-        $purchaseUnit = self::PURCHASE_UNIT + [
-            'payee' => ['merchant_id' => 'MERCHANT_ID'],
-            'invoice_id' => 'INVOICE_ID',
-            'soft_descriptor' => 'Sylius PayPal Payment',
-        ];
-        $response = ($this->action)($this->callbackRequest(['purchase_units' => [$purchaseUnit]]));
-
-        $content = json_decode((string) $response->getContent(), true);
-
-        self::assertSame(
-            ['reference_id', 'amount', 'shipping_options'],
-            array_keys($content['purchase_units'][0]),
         );
     }
 }

--- a/tests/Unit/Controller/PayPalOrderShippingCallbackActionTest.php
+++ b/tests/Unit/Controller/PayPalOrderShippingCallbackActionTest.php
@@ -23,6 +23,7 @@ use Sylius\PayPalPlugin\Controller\PayPalOrderShippingCallbackAction;
 use Sylius\PayPalPlugin\Exception\PaymentNotFoundException;
 use Sylius\PayPalPlugin\Factory\PayPalShippingAddressFactoryInterface;
 use Sylius\PayPalPlugin\Factory\PayPalShippingCallbackResponseFactoryInterface;
+use Sylius\PayPalPlugin\Model\PayPalShippingOption;
 use Sylius\PayPalPlugin\Provider\ChannelAvailableCountriesProviderInterface;
 use Sylius\PayPalPlugin\Repository\Query\PaypalPaymentQueryInterface;
 use Sylius\PayPalPlugin\Resolver\PayPalShippingOptionsResolverInterface;
@@ -49,10 +50,6 @@ final class PayPalOrderShippingCallbackActionTest extends TestCase
                 'shipping' => ['currency_code' => 'USD', 'value' => '0.00'],
             ],
         ],
-    ];
-
-    private const SHIPPING_OPTIONS = [
-        ['id' => 'ups', 'amount' => ['currency_code' => 'USD', 'value' => '10.00'], 'type' => 'SHIPPING', 'label' => 'UPS', 'selected' => true],
     ];
 
     private PaypalPaymentQueryInterface&MockObject $paypalPaymentQuery;
@@ -108,11 +105,11 @@ final class PayPalOrderShippingCallbackActionTest extends TestCase
             ->expects(self::once())
             ->method('resolve')
             ->with($this->order, $address)
-            ->willReturn(self::SHIPPING_OPTIONS);
+            ->willReturn(self::shippingOptions());
         $this->responseFactory
             ->expects(self::once())
             ->method('create')
-            ->with('PAYPAL_ORDER_ID', self::PURCHASE_UNIT, self::SHIPPING_OPTIONS)
+            ->with('PAYPAL_ORDER_ID', self::PURCHASE_UNIT, self::shippingOptions())
             ->willReturn(['id' => 'PAYPAL_ORDER_ID', 'purchase_units' => ['RESPONSE_UNIT']]);
 
         $response = ($this->action)($this->callbackRequest());
@@ -186,6 +183,12 @@ final class PayPalOrderShippingCallbackActionTest extends TestCase
         ];
 
         return new Request([], [], [], [], [], ['CONTENT_TYPE' => 'application/json'], (string) json_encode($payload));
+    }
+
+    /** @return array<int, PayPalShippingOption> */
+    private static function shippingOptions(): array
+    {
+        return [new PayPalShippingOption('ups', 'UPS', 'USD', 1000, true)];
     }
 
     private static function assertUnprocessableWithIssue(string $issue, Response $response): void

--- a/tests/Unit/Factory/PayPalOrderFactoryTest.php
+++ b/tests/Unit/Factory/PayPalOrderFactoryTest.php
@@ -55,7 +55,7 @@ final class PayPalOrderFactoryTest extends TestCase
         $this->router->method('generate')->willReturn('https://shop.example.com/checkout/complete');
         $this->shippingCallbackUrlProvider
             ->method('provide')
-            ->willReturn('https://shop.example.com/pay-pal-order-shipping-callback')
+            ->willReturn('https://shop.example.com/paypal/order-shipping-callback')
         ;
         $this->payPalPurchaseUnitFactory->method('create')->willReturn($this->purchaseUnit());
 
@@ -101,7 +101,7 @@ final class PayPalOrderFactoryTest extends TestCase
             'cancel_url' => 'https://shop.example.com/checkout/complete',
             'order_update_callback_config' => [
                 'callback_events' => ['SHIPPING_ADDRESS'],
-                'callback_url' => 'https://shop.example.com/pay-pal-order-shipping-callback',
+                'callback_url' => 'https://shop.example.com/paypal/order-shipping-callback',
             ],
         ], $payPalOrder['payment_source']['paypal']['experience_context']);
     }

--- a/tests/Unit/Factory/PayPalOrderFactoryTest.php
+++ b/tests/Unit/Factory/PayPalOrderFactoryTest.php
@@ -1,0 +1,166 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\PayPalPlugin\Unit\Factory;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Core\Model\AddressInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\PayPalPlugin\Factory\PayPalOrderFactory;
+use Sylius\PayPalPlugin\Factory\PayPalOrderFactoryInterface;
+use Sylius\PayPalPlugin\Factory\PayPalPurchaseUnitFactoryInterface;
+use Sylius\PayPalPlugin\Model\PayPalPurchaseUnit;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class PayPalOrderFactoryTest extends TestCase
+{
+    private PayPalPurchaseUnitFactoryInterface&MockObject $payPalPurchaseUnitFactory;
+
+    private UrlGeneratorInterface&MockObject $router;
+
+    private OrderInterface&MockObject $order;
+
+    private PaymentInterface&MockObject $payment;
+
+    private string $shopScheme = 'https';
+
+    private PayPalOrderFactory $factory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->payPalPurchaseUnitFactory = $this->createMock(PayPalPurchaseUnitFactoryInterface::class);
+        $this->router = $this->createMock(UrlGeneratorInterface::class);
+        $this->order = $this->createMock(OrderInterface::class);
+        $this->payment = $this->createMock(PaymentInterface::class);
+
+        $this->payment->method('getOrder')->willReturn($this->order);
+        $this->order->method('isShippingRequired')->willReturn(true);
+        $this->order->method('getShippingAddress')->willReturn(null);
+
+        $this->router->method('generate')->willReturnCallback($this->routeUrl(...));
+        $this->payPalPurchaseUnitFactory->method('create')->willReturn($this->purchaseUnit());
+
+        $this->factory = new PayPalOrderFactory($this->payPalPurchaseUnitFactory, $this->router);
+    }
+
+    public function test_it_implements_paypal_order_factory_interface(): void
+    {
+        self::assertInstanceOf(PayPalOrderFactoryInterface::class, $this->factory);
+    }
+
+    public function test_it_captures_and_delegates_the_purchase_unit_to_its_own_factory(): void
+    {
+        $payPalPurchaseUnitFactory = $this->createMock(PayPalPurchaseUnitFactoryInterface::class);
+        $payPalPurchaseUnitFactory
+            ->expects(self::once())
+            ->method('create')
+            ->with($this->payment, 'REFERENCE_ID')
+            ->willReturn($this->purchaseUnit())
+        ;
+
+        $payPalOrder = (new PayPalOrderFactory($payPalPurchaseUnitFactory, $this->router))
+            ->create($this->payment, 'REFERENCE_ID')
+            ->toArray()
+        ;
+
+        self::assertSame('CAPTURE', $payPalOrder['intent']);
+        self::assertSame('REFERENCE_ID', $payPalOrder['purchase_units'][0]['reference_id']);
+    }
+
+    public function test_it_sends_the_same_return_and_cancel_url_on_orders_addressed_in_the_wallet(): void
+    {
+        $payPalOrder = $this->factory->create($this->payment, 'REFERENCE_ID')->toArray();
+
+        self::assertSame([
+            'shipping_preference' => 'GET_FROM_FILE',
+            'user_action' => 'PAY_NOW',
+            'return_url' => 'https://shop.example.com/checkout/complete',
+            'cancel_url' => 'https://shop.example.com/checkout/complete',
+            'order_update_callback_config' => [
+                'callback_events' => ['SHIPPING_ADDRESS'],
+                'callback_url' => 'https://shop.example.com/pay-pal-order-shipping-callback',
+            ],
+        ], $payPalOrder['payment_source']['paypal']['experience_context']);
+    }
+
+    public function test_it_does_not_select_a_payment_source_on_orders_that_already_carry_an_address(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('isShippingRequired')->willReturn(true);
+        $order->method('getShippingAddress')->willReturn($this->createMock(AddressInterface::class));
+
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->method('getOrder')->willReturn($order);
+
+        $payPalOrder = $this->factory->create($payment, 'REFERENCE_ID')->toArray();
+
+        self::assertArrayNotHasKey('payment_source', $payPalOrder);
+        self::assertSame('SET_PROVIDED_ADDRESS', $payPalOrder['application_context']['shipping_preference']);
+    }
+
+    public function test_it_does_not_declare_a_shipping_callback_paypal_could_not_reach(): void
+    {
+        $this->shopScheme = 'http';
+
+        $experienceContext = $this->factory
+            ->create($this->payment, 'REFERENCE_ID')
+            ->toArray()['payment_source']['paypal']['experience_context']
+        ;
+
+        self::assertArrayNotHasKey('order_update_callback_config', $experienceContext);
+        self::assertSame('http://shop.example.com/checkout/complete', $experienceContext['return_url']);
+    }
+
+    public function test_it_sends_no_urls_at_all_without_a_router(): void
+    {
+        $payPalOrder = (new PayPalOrderFactory($this->payPalPurchaseUnitFactory))
+            ->create($this->payment, 'REFERENCE_ID')
+            ->toArray()
+        ;
+
+        self::assertSame([
+            'shipping_preference' => 'GET_FROM_FILE',
+            'user_action' => 'PAY_NOW',
+        ], $payPalOrder['payment_source']['paypal']['experience_context']);
+    }
+
+    private function purchaseUnit(): PayPalPurchaseUnit
+    {
+        return new PayPalPurchaseUnit(
+            'REFERENCE_ID',
+            'REFERENCE-NUMBER',
+            'PLN',
+            10000,
+            1000,
+            90.00,
+            0.00,
+            0,
+            'merchant-id',
+            [],
+            true,
+        );
+    }
+
+    private function routeUrl(string $route): string
+    {
+        $path = match ($route) {
+            'sylius_shop_checkout_complete' => '/checkout/complete',
+            'sylius_paypal_shop_order_shipping_callback' => '/pay-pal-order-shipping-callback',
+        };
+
+        return $this->shopScheme . '://shop.example.com' . $path;
+    }
+}

--- a/tests/Unit/Factory/PayPalOrderFactoryTest.php
+++ b/tests/Unit/Factory/PayPalOrderFactoryTest.php
@@ -22,6 +22,7 @@ use Sylius\PayPalPlugin\Factory\PayPalOrderFactory;
 use Sylius\PayPalPlugin\Factory\PayPalOrderFactoryInterface;
 use Sylius\PayPalPlugin\Factory\PayPalPurchaseUnitFactoryInterface;
 use Sylius\PayPalPlugin\Model\PayPalPurchaseUnit;
+use Sylius\PayPalPlugin\Provider\PayPalShippingCallbackUrlProviderInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 final class PayPalOrderFactoryTest extends TestCase
@@ -30,11 +31,11 @@ final class PayPalOrderFactoryTest extends TestCase
 
     private UrlGeneratorInterface&MockObject $router;
 
+    private PayPalShippingCallbackUrlProviderInterface&MockObject $shippingCallbackUrlProvider;
+
     private OrderInterface&MockObject $order;
 
     private PaymentInterface&MockObject $payment;
-
-    private string $shopScheme = 'https';
 
     private PayPalOrderFactory $factory;
 
@@ -43,6 +44,7 @@ final class PayPalOrderFactoryTest extends TestCase
         parent::setUp();
         $this->payPalPurchaseUnitFactory = $this->createMock(PayPalPurchaseUnitFactoryInterface::class);
         $this->router = $this->createMock(UrlGeneratorInterface::class);
+        $this->shippingCallbackUrlProvider = $this->createMock(PayPalShippingCallbackUrlProviderInterface::class);
         $this->order = $this->createMock(OrderInterface::class);
         $this->payment = $this->createMock(PaymentInterface::class);
 
@@ -50,10 +52,18 @@ final class PayPalOrderFactoryTest extends TestCase
         $this->order->method('isShippingRequired')->willReturn(true);
         $this->order->method('getShippingAddress')->willReturn(null);
 
-        $this->router->method('generate')->willReturnCallback($this->routeUrl(...));
+        $this->router->method('generate')->willReturn('https://shop.example.com/checkout/complete');
+        $this->shippingCallbackUrlProvider
+            ->method('provide')
+            ->willReturn('https://shop.example.com/pay-pal-order-shipping-callback')
+        ;
         $this->payPalPurchaseUnitFactory->method('create')->willReturn($this->purchaseUnit());
 
-        $this->factory = new PayPalOrderFactory($this->payPalPurchaseUnitFactory, $this->router);
+        $this->factory = new PayPalOrderFactory(
+            $this->payPalPurchaseUnitFactory,
+            $this->router,
+            $this->shippingCallbackUrlProvider,
+        );
     }
 
     public function test_it_implements_paypal_order_factory_interface(): void
@@ -111,17 +121,22 @@ final class PayPalOrderFactoryTest extends TestCase
         self::assertSame('SET_PROVIDED_ADDRESS', $payPalOrder['application_context']['shipping_preference']);
     }
 
-    public function test_it_does_not_declare_a_shipping_callback_paypal_could_not_reach(): void
+    public function test_it_declares_no_shipping_callback_when_its_provider_has_no_url_to_give(): void
     {
-        $this->shopScheme = 'http';
+        $shippingCallbackUrlProvider = $this->createMock(PayPalShippingCallbackUrlProviderInterface::class);
+        $shippingCallbackUrlProvider->method('provide')->willReturn(null);
 
-        $experienceContext = $this->factory
+        $experienceContext = (new PayPalOrderFactory(
+            $this->payPalPurchaseUnitFactory,
+            $this->router,
+            $shippingCallbackUrlProvider,
+        ))
             ->create($this->payment, 'REFERENCE_ID')
             ->toArray()['payment_source']['paypal']['experience_context']
         ;
 
         self::assertArrayNotHasKey('order_update_callback_config', $experienceContext);
-        self::assertSame('http://shop.example.com/checkout/complete', $experienceContext['return_url']);
+        self::assertSame('https://shop.example.com/checkout/complete', $experienceContext['return_url']);
     }
 
     public function test_it_sends_no_urls_at_all_without_a_router(): void
@@ -152,15 +167,5 @@ final class PayPalOrderFactoryTest extends TestCase
             [],
             true,
         );
-    }
-
-    private function routeUrl(string $route): string
-    {
-        $path = match ($route) {
-            'sylius_shop_checkout_complete' => '/checkout/complete',
-            'sylius_paypal_shop_order_shipping_callback' => '/pay-pal-order-shipping-callback',
-        };
-
-        return $this->shopScheme . '://shop.example.com' . $path;
     }
 }

--- a/tests/Unit/Factory/PayPalPurchaseUnitFactoryTest.php
+++ b/tests/Unit/Factory/PayPalPurchaseUnitFactoryTest.php
@@ -1,0 +1,192 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\PayPalPlugin\Unit\Factory;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Core\Model\AddressInterface;
+use Sylius\Component\Core\Model\AdjustmentInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\Model\PaymentMethodInterface;
+use Sylius\Component\Payment\Model\GatewayConfigInterface;
+use Sylius\PayPalPlugin\Factory\PayPalPurchaseUnitFactory;
+use Sylius\PayPalPlugin\Factory\PayPalPurchaseUnitFactoryInterface;
+use Sylius\PayPalPlugin\Provider\PaymentReferenceNumberProviderInterface;
+use Sylius\PayPalPlugin\Provider\PayPalItemDataProviderInterface;
+
+final class PayPalPurchaseUnitFactoryTest extends TestCase
+{
+    private PaymentReferenceNumberProviderInterface&MockObject $paymentReferenceNumberProvider;
+
+    private PayPalItemDataProviderInterface&MockObject $payPalItemDataProvider;
+
+    private OrderInterface&MockObject $order;
+
+    private GatewayConfigInterface&MockObject $gatewayConfig;
+
+    private PaymentInterface&MockObject $payment;
+
+    private PayPalPurchaseUnitFactory $factory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->paymentReferenceNumberProvider = $this->createMock(PaymentReferenceNumberProviderInterface::class);
+        $this->payPalItemDataProvider = $this->createMock(PayPalItemDataProviderInterface::class);
+        $this->order = $this->createMock(OrderInterface::class);
+        $this->gatewayConfig = $this->createMock(GatewayConfigInterface::class);
+        $this->payment = $this->createMock(PaymentInterface::class);
+
+        $paymentMethod = $this->createMock(PaymentMethodInterface::class);
+        $paymentMethod->method('getGatewayConfig')->willReturn($this->gatewayConfig);
+
+        $this->payment->method('getOrder')->willReturn($this->order);
+        $this->payment->method('getMethod')->willReturn($paymentMethod);
+        $this->payment->method('getAmount')->willReturn(10000);
+
+        $this->order->method('getCurrencyCode')->willReturn('PLN');
+        $this->order->method('getShippingTotal')->willReturn(1000);
+        $this->order->method('isShippingRequired')->willReturn(true);
+        $this->order->method('getShippingAddress')->willReturn(null);
+        $this->order->method('getOrderPromotionTotal')->willReturn(0);
+        $this->order
+            ->method('getAdjustmentsTotalRecursively')
+            ->with(AdjustmentInterface::ORDER_SHIPPING_PROMOTION_ADJUSTMENT)
+            ->willReturn(0);
+
+        $this->gatewayConfig->method('getConfig')->willReturn(
+            ['merchant_id' => 'merchant-id', 'sylius_merchant_id' => 'sylius-merchant-id'],
+        );
+
+        $this->paymentReferenceNumberProvider->method('provide')->with($this->payment)->willReturn('REFERENCE-NUMBER');
+        $this->payPalItemDataProvider->method('provide')->with($this->order)->willReturn([
+            'items' => [
+                [
+                    'name' => 'PRODUCT_ONE',
+                    'unit_amount' => ['value' => '90.00', 'currency_code' => 'PLN'],
+                    'quantity' => 1,
+                    'tax' => ['value' => '0.00', 'currency_code' => 'PLN'],
+                ],
+            ],
+            'total_item_value' => '90.00',
+            'total_tax' => '0.00',
+        ]);
+
+        $this->factory = new PayPalPurchaseUnitFactory(
+            $this->paymentReferenceNumberProvider,
+            $this->payPalItemDataProvider,
+        );
+    }
+
+    public function test_it_implements_paypal_purchase_unit_factory_interface(): void
+    {
+        self::assertInstanceOf(PayPalPurchaseUnitFactoryInterface::class, $this->factory);
+    }
+
+    public function test_it_builds_the_purchase_unit_from_the_payment_and_its_order(): void
+    {
+        $purchaseUnit = $this->factory->create($this->payment, 'REFERENCE_ID')->toArray();
+
+        self::assertSame('REFERENCE_ID', $purchaseUnit['reference_id']);
+        self::assertSame('REFERENCE-NUMBER', $purchaseUnit['invoice_id']);
+        self::assertSame('PLN', $purchaseUnit['amount']['currency_code']);
+        self::assertSame('100.00', $purchaseUnit['amount']['value']);
+        self::assertSame(
+            ['currency_code' => 'PLN', 'value' => '10.00'],
+            $purchaseUnit['amount']['breakdown']['shipping'],
+        );
+        self::assertSame(
+            ['currency_code' => 'PLN', 'value' => '90.00'],
+            $purchaseUnit['amount']['breakdown']['item_total'],
+        );
+        self::assertSame('PRODUCT_ONE', $purchaseUnit['items'][0]['name']);
+        self::assertSame('90.00', $purchaseUnit['items'][0]['unit_amount']['value']);
+    }
+
+    public function test_it_takes_the_merchant_id_from_the_payment_method_gateway_config(): void
+    {
+        $purchaseUnit = $this->factory->create($this->payment, 'REFERENCE_ID')->toArray();
+
+        self::assertSame('merchant-id', $purchaseUnit['payee']['merchant_id']);
+    }
+
+    public function test_it_prefers_the_merchant_id_it_is_given_over_the_configured_one(): void
+    {
+        $purchaseUnit = $this->factory->create($this->payment, 'REFERENCE_ID', 'other-merchant-id')->toArray();
+
+        self::assertSame('other-merchant-id', $purchaseUnit['payee']['merchant_id']);
+    }
+
+    public function test_it_sends_the_shipping_address_when_the_order_carries_one(): void
+    {
+        $shippingAddress = $this->createMock(AddressInterface::class);
+        $shippingAddress->method('getFullName')->willReturn('Gandalf The Grey');
+        $shippingAddress->method('getStreet')->willReturn('Hobbit St. 123');
+        $shippingAddress->method('getCity')->willReturn('Minas Tirith');
+        $shippingAddress->method('getPostcode')->willReturn('000');
+        $shippingAddress->method('getCountryCode')->willReturn('US');
+
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getCurrencyCode')->willReturn('PLN');
+        $order->method('getShippingTotal')->willReturn(1000);
+        $order->method('isShippingRequired')->willReturn(true);
+        $order->method('getShippingAddress')->willReturn($shippingAddress);
+        $order->method('getOrderPromotionTotal')->willReturn(0);
+        $order->method('getAdjustmentsTotalRecursively')->willReturn(0);
+
+        $payment = $this->createMock(PaymentInterface::class);
+        $paymentMethod = $this->createMock(PaymentMethodInterface::class);
+        $paymentMethod->method('getGatewayConfig')->willReturn($this->gatewayConfig);
+        $payment->method('getOrder')->willReturn($order);
+        $payment->method('getMethod')->willReturn($paymentMethod);
+        $payment->method('getAmount')->willReturn(10000);
+
+        $paymentReferenceNumberProvider = $this->createMock(PaymentReferenceNumberProviderInterface::class);
+        $paymentReferenceNumberProvider->method('provide')->willReturn('REFERENCE-NUMBER');
+        $payPalItemDataProvider = $this->createMock(PayPalItemDataProviderInterface::class);
+        $payPalItemDataProvider->method('provide')->willReturn([
+            'items' => [],
+            'total_item_value' => '90.00',
+            'total_tax' => '0.00',
+        ]);
+
+        $factory = new PayPalPurchaseUnitFactory($paymentReferenceNumberProvider, $payPalItemDataProvider);
+        $purchaseUnit = $factory->create($payment, 'REFERENCE_ID')->toArray();
+
+        self::assertSame('Gandalf The Grey', $purchaseUnit['shipping']['name']['full_name']);
+        self::assertSame('Hobbit St. 123', $purchaseUnit['shipping']['address']['address_line_1']);
+        self::assertSame('Minas Tirith', $purchaseUnit['shipping']['address']['admin_area_2']);
+        self::assertSame('000', $purchaseUnit['shipping']['address']['postal_code']);
+        self::assertSame('US', $purchaseUnit['shipping']['address']['country_code']);
+    }
+
+    public function test_it_fails_when_the_gateway_config_carries_no_merchant_id(): void
+    {
+        $gatewayConfig = $this->createMock(GatewayConfigInterface::class);
+        $gatewayConfig->method('getConfig')->willReturn(['sylius_merchant_id' => 'sylius-merchant-id']);
+
+        $paymentMethod = $this->createMock(PaymentMethodInterface::class);
+        $paymentMethod->method('getGatewayConfig')->willReturn($gatewayConfig);
+
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->method('getOrder')->willReturn($this->order);
+        $payment->method('getMethod')->willReturn($paymentMethod);
+        $payment->method('getAmount')->willReturn(10000);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->factory->create($payment, 'REFERENCE_ID');
+    }
+}

--- a/tests/Unit/Factory/PayPalShippingAddressFactoryTest.php
+++ b/tests/Unit/Factory/PayPalShippingAddressFactoryTest.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\PayPalPlugin\Unit\Resolver;
+namespace Tests\Sylius\PayPalPlugin\Unit\Factory;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -19,16 +19,16 @@ use Sylius\Component\Addressing\Model\ProvinceInterface;
 use Sylius\Component\Core\Factory\AddressFactoryInterface;
 use Sylius\Component\Core\Model\Address;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
-use Sylius\PayPalPlugin\Resolver\PayPalShippingAddressResolver;
-use Sylius\PayPalPlugin\Resolver\PayPalShippingAddressResolverInterface;
+use Sylius\PayPalPlugin\Factory\PayPalShippingAddressFactory;
+use Sylius\PayPalPlugin\Factory\PayPalShippingAddressFactoryInterface;
 
-final class PayPalShippingAddressResolverTest extends TestCase
+final class PayPalShippingAddressFactoryTest extends TestCase
 {
     private AddressFactoryInterface&MockObject $addressFactory;
 
     private RepositoryInterface&MockObject $provinceRepository;
 
-    private PayPalShippingAddressResolver $resolver;
+    private PayPalShippingAddressFactory $factory;
 
     protected function setUp(): void
     {
@@ -37,19 +37,19 @@ final class PayPalShippingAddressResolverTest extends TestCase
         $this->provinceRepository = $this->createMock(RepositoryInterface::class);
         $this->addressFactory->method('createNew')->willReturnCallback(fn (): Address => new Address());
 
-        $this->resolver = new PayPalShippingAddressResolver($this->addressFactory, $this->provinceRepository);
+        $this->factory = new PayPalShippingAddressFactory($this->addressFactory, $this->provinceRepository);
     }
 
-    public function test_it_implements_paypal_shipping_address_resolver_interface(): void
+    public function test_it_implements_paypal_shipping_address_factory_interface(): void
     {
-        self::assertInstanceOf(PayPalShippingAddressResolverInterface::class, $this->resolver);
+        self::assertInstanceOf(PayPalShippingAddressFactoryInterface::class, $this->factory);
     }
 
     public function test_it_maps_the_redacted_address_paypal_sends(): void
     {
         $this->provinceRepository->method('findOneBy')->willReturn(null);
 
-        $address = $this->resolver->resolve([
+        $address = $this->factory->create([
             'country_code' => 'US',
             'admin_area_1' => 'TX',
             'admin_area_2' => 'Dallas',
@@ -66,7 +66,7 @@ final class PayPalShippingAddressResolverTest extends TestCase
         $province = $this->createMock(ProvinceInterface::class);
         $this->provinceRepository->expects(self::once())->method('findOneBy')->with(['code' => 'US-TX'])->willReturn($province);
 
-        $address = $this->resolver->resolve(['country_code' => 'US', 'admin_area_1' => 'TX']);
+        $address = $this->factory->create(['country_code' => 'US', 'admin_area_1' => 'TX']);
 
         self::assertSame('US-TX', $address->getProvinceCode());
     }
@@ -78,7 +78,7 @@ final class PayPalShippingAddressResolverTest extends TestCase
             ->method('findOneBy')
             ->willReturnCallback(fn (array $criteria): ?ProvinceInterface => $criteria === ['code' => 'TX'] ? $province : null);
 
-        $address = $this->resolver->resolve(['country_code' => 'US', 'admin_area_1' => 'TX']);
+        $address = $this->factory->create(['country_code' => 'US', 'admin_area_1' => 'TX']);
 
         self::assertSame('TX', $address->getProvinceCode());
     }
@@ -87,7 +87,7 @@ final class PayPalShippingAddressResolverTest extends TestCase
     {
         $this->provinceRepository->method('findOneBy')->willReturn(null);
 
-        $address = $this->resolver->resolve(['country_code' => 'PL', 'admin_area_1' => 'Mazowieckie']);
+        $address = $this->factory->create(['country_code' => 'PL', 'admin_area_1' => 'Mazowieckie']);
 
         self::assertNull($address->getProvinceCode());
         self::assertSame('Mazowieckie', $address->getProvinceName());
@@ -97,7 +97,7 @@ final class PayPalShippingAddressResolverTest extends TestCase
     {
         $this->provinceRepository->method('findOneBy')->willReturn($this->createMock(ProvinceInterface::class));
 
-        $address = $this->resolver->resolve(['country_code' => 'US', 'admin_area_1' => 'TX']);
+        $address = $this->factory->create(['country_code' => 'US', 'admin_area_1' => 'TX']);
 
         self::assertSame('US-TX', $address->getProvinceCode());
         self::assertNull($address->getProvinceName());
@@ -107,7 +107,7 @@ final class PayPalShippingAddressResolverTest extends TestCase
     {
         $this->provinceRepository->expects(self::never())->method('findOneBy');
 
-        $address = $this->resolver->resolve(['country_code' => 'DE']);
+        $address = $this->factory->create(['country_code' => 'DE']);
 
         self::assertSame('DE', $address->getCountryCode());
         self::assertNull($address->getCity());
@@ -120,7 +120,7 @@ final class PayPalShippingAddressResolverTest extends TestCase
     {
         $this->provinceRepository->expects(self::never())->method('findOneBy');
 
-        $address = $this->resolver->resolve([
+        $address = $this->factory->create([
             'country_code' => 'DE',
             'admin_area_1' => '   ',
             'admin_area_2' => '',

--- a/tests/Unit/Factory/PayPalShippingCallbackResponseFactoryTest.php
+++ b/tests/Unit/Factory/PayPalShippingCallbackResponseFactoryTest.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\PayPalPlugin\Unit\Factory;
+
+use PHPUnit\Framework\TestCase;
+use Sylius\PayPalPlugin\Factory\PayPalShippingCallbackResponseFactory;
+use Sylius\PayPalPlugin\Factory\PayPalShippingCallbackResponseFactoryInterface;
+
+final class PayPalShippingCallbackResponseFactoryTest extends TestCase
+{
+    private const PURCHASE_UNIT = [
+        'reference_id' => 'REFERENCE_ID',
+        'amount' => [
+            'currency_code' => 'USD',
+            'value' => '100.00',
+            'breakdown' => [
+                'item_total' => ['currency_code' => 'USD', 'value' => '90.00'],
+                'tax_total' => ['currency_code' => 'USD', 'value' => '10.00'],
+                'shipping' => ['currency_code' => 'USD', 'value' => '0.00'],
+            ],
+        ],
+    ];
+
+    private const SHIPPING_OPTIONS = [
+        ['id' => 'ups', 'amount' => ['currency_code' => 'USD', 'value' => '10.00'], 'type' => 'SHIPPING', 'label' => 'UPS', 'selected' => false],
+        ['id' => 'dhl', 'amount' => ['currency_code' => 'USD', 'value' => '25.50'], 'type' => 'SHIPPING', 'label' => 'DHL', 'selected' => true],
+    ];
+
+    private PayPalShippingCallbackResponseFactory $factory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->factory = new PayPalShippingCallbackResponseFactory();
+    }
+
+    public function test_it_implements_paypal_shipping_callback_response_factory_interface(): void
+    {
+        self::assertInstanceOf(PayPalShippingCallbackResponseFactoryInterface::class, $this->factory);
+    }
+
+    public function test_it_answers_with_the_options_and_the_cost_of_the_selected_one(): void
+    {
+        $response = $this->factory->create('PAYPAL_ORDER_ID', self::PURCHASE_UNIT, self::SHIPPING_OPTIONS);
+
+        self::assertSame([
+            'id' => 'PAYPAL_ORDER_ID',
+            'purchase_units' => [[
+                'reference_id' => 'REFERENCE_ID',
+                'amount' => [
+                    'currency_code' => 'USD',
+                    'value' => '125.50',
+                    'breakdown' => [
+                        'item_total' => ['currency_code' => 'USD', 'value' => '90.00'],
+                        'tax_total' => ['currency_code' => 'USD', 'value' => '10.00'],
+                        'shipping' => ['currency_code' => 'USD', 'value' => '25.50'],
+                    ],
+                ],
+                'shipping_options' => self::SHIPPING_OPTIONS,
+            ]],
+        ], $response);
+    }
+
+    public function test_it_keeps_the_total_equal_to_the_sum_of_the_breakdown(): void
+    {
+        $purchaseUnit = ['amount' => ['currency_code' => 'USD', 'value' => '0.00', 'breakdown' => [
+            'item_total' => ['currency_code' => 'USD', 'value' => '90.00'],
+            'tax_total' => ['currency_code' => 'USD', 'value' => '7.13'],
+            'handling' => ['currency_code' => 'USD', 'value' => '1.50'],
+            'insurance' => ['currency_code' => 'USD', 'value' => '2.25'],
+            'discount' => ['currency_code' => 'USD', 'value' => '5.00'],
+            'shipping_discount' => ['currency_code' => 'USD', 'value' => '3.30'],
+        ]]];
+
+        $amount = $this->factory
+            ->create('PAYPAL_ORDER_ID', $purchaseUnit, self::SHIPPING_OPTIONS)['purchase_units'][0]['amount']
+        ;
+
+        // 90.00 + 7.13 + 25.50 + 1.50 + 2.25 - 5.00 - 3.30
+        self::assertSame('118.08', $amount['value']);
+    }
+
+    public function test_it_leaves_an_amount_without_a_breakdown_alone(): void
+    {
+        $amount = ['currency_code' => 'USD', 'value' => '100.00'];
+
+        $response = $this->factory->create('PAYPAL_ORDER_ID', ['amount' => $amount], self::SHIPPING_OPTIONS);
+
+        self::assertSame($amount, $response['purchase_units'][0]['amount']);
+    }
+
+    public function test_it_leaves_the_amount_alone_when_no_option_is_selected(): void
+    {
+        $options = [
+            ['id' => 'ups', 'amount' => ['currency_code' => 'USD', 'value' => '10.00'], 'selected' => false],
+        ];
+
+        $amount = $this->factory
+            ->create('PAYPAL_ORDER_ID', self::PURCHASE_UNIT, $options)['purchase_units'][0]['amount']
+        ;
+
+        self::assertSame(self::PURCHASE_UNIT['amount'], $amount);
+    }
+
+    public function test_it_drops_the_purchase_unit_fields_paypal_does_not_read_back(): void
+    {
+        $purchaseUnit = self::PURCHASE_UNIT + [
+            'payee' => ['merchant_id' => 'MERCHANT_ID'],
+            'invoice_id' => 'INVOICE_ID',
+            'soft_descriptor' => 'Sylius PayPal Payment',
+        ];
+
+        $response = $this->factory->create('PAYPAL_ORDER_ID', $purchaseUnit, self::SHIPPING_OPTIONS);
+
+        self::assertSame(
+            ['reference_id', 'amount', 'shipping_options'],
+            array_keys($response['purchase_units'][0]),
+        );
+    }
+
+    public function test_it_omits_a_reference_id_the_request_did_not_carry(): void
+    {
+        $response = $this->factory->create('PAYPAL_ORDER_ID', ['amount' => []], self::SHIPPING_OPTIONS);
+
+        self::assertSame(['amount', 'shipping_options'], array_keys($response['purchase_units'][0]));
+    }
+}

--- a/tests/Unit/Factory/PayPalShippingCallbackResponseFactoryTest.php
+++ b/tests/Unit/Factory/PayPalShippingCallbackResponseFactoryTest.php
@@ -16,6 +16,7 @@ namespace Tests\Sylius\PayPalPlugin\Unit\Factory;
 use PHPUnit\Framework\TestCase;
 use Sylius\PayPalPlugin\Factory\PayPalShippingCallbackResponseFactory;
 use Sylius\PayPalPlugin\Factory\PayPalShippingCallbackResponseFactoryInterface;
+use Sylius\PayPalPlugin\Model\PayPalShippingOption;
 
 final class PayPalShippingCallbackResponseFactoryTest extends TestCase
 {
@@ -32,17 +33,21 @@ final class PayPalShippingCallbackResponseFactoryTest extends TestCase
         ],
     ];
 
-    private const SHIPPING_OPTIONS = [
-        ['id' => 'ups', 'amount' => ['currency_code' => 'USD', 'value' => '10.00'], 'type' => 'SHIPPING', 'label' => 'UPS', 'selected' => false],
-        ['id' => 'dhl', 'amount' => ['currency_code' => 'USD', 'value' => '25.50'], 'type' => 'SHIPPING', 'label' => 'DHL', 'selected' => true],
-    ];
-
     private PayPalShippingCallbackResponseFactory $factory;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->factory = new PayPalShippingCallbackResponseFactory();
+    }
+
+    /** @return array<int, PayPalShippingOption> */
+    private static function shippingOptions(): array
+    {
+        return [
+            new PayPalShippingOption('ups', 'UPS', 'USD', 1000),
+            new PayPalShippingOption('dhl', 'DHL', 'USD', 2550, true),
+        ];
     }
 
     public function test_it_implements_paypal_shipping_callback_response_factory_interface(): void
@@ -52,7 +57,7 @@ final class PayPalShippingCallbackResponseFactoryTest extends TestCase
 
     public function test_it_answers_with_the_options_and_the_cost_of_the_selected_one(): void
     {
-        $response = $this->factory->create('PAYPAL_ORDER_ID', self::PURCHASE_UNIT, self::SHIPPING_OPTIONS);
+        $response = $this->factory->create('PAYPAL_ORDER_ID', self::PURCHASE_UNIT, self::shippingOptions());
 
         self::assertSame([
             'id' => 'PAYPAL_ORDER_ID',
@@ -67,7 +72,10 @@ final class PayPalShippingCallbackResponseFactoryTest extends TestCase
                         'shipping' => ['currency_code' => 'USD', 'value' => '25.50'],
                     ],
                 ],
-                'shipping_options' => self::SHIPPING_OPTIONS,
+                'shipping_options' => [
+                    ['id' => 'ups', 'amount' => ['currency_code' => 'USD', 'value' => '10.00'], 'type' => 'SHIPPING', 'label' => 'UPS', 'selected' => false],
+                    ['id' => 'dhl', 'amount' => ['currency_code' => 'USD', 'value' => '25.50'], 'type' => 'SHIPPING', 'label' => 'DHL', 'selected' => true],
+                ],
             ]],
         ], $response);
     }
@@ -84,7 +92,7 @@ final class PayPalShippingCallbackResponseFactoryTest extends TestCase
         ]]];
 
         $amount = $this->factory
-            ->create('PAYPAL_ORDER_ID', $purchaseUnit, self::SHIPPING_OPTIONS)['purchase_units'][0]['amount']
+            ->create('PAYPAL_ORDER_ID', $purchaseUnit, self::shippingOptions())['purchase_units'][0]['amount']
         ;
 
         // 90.00 + 7.13 + 25.50 + 1.50 + 2.25 - 5.00 - 3.30
@@ -95,16 +103,14 @@ final class PayPalShippingCallbackResponseFactoryTest extends TestCase
     {
         $amount = ['currency_code' => 'USD', 'value' => '100.00'];
 
-        $response = $this->factory->create('PAYPAL_ORDER_ID', ['amount' => $amount], self::SHIPPING_OPTIONS);
+        $response = $this->factory->create('PAYPAL_ORDER_ID', ['amount' => $amount], self::shippingOptions());
 
         self::assertSame($amount, $response['purchase_units'][0]['amount']);
     }
 
     public function test_it_leaves_the_amount_alone_when_no_option_is_selected(): void
     {
-        $options = [
-            ['id' => 'ups', 'amount' => ['currency_code' => 'USD', 'value' => '10.00'], 'selected' => false],
-        ];
+        $options = [new PayPalShippingOption('ups', 'UPS', 'USD', 1000)];
 
         $amount = $this->factory
             ->create('PAYPAL_ORDER_ID', self::PURCHASE_UNIT, $options)['purchase_units'][0]['amount']
@@ -121,7 +127,7 @@ final class PayPalShippingCallbackResponseFactoryTest extends TestCase
             'soft_descriptor' => 'Sylius PayPal Payment',
         ];
 
-        $response = $this->factory->create('PAYPAL_ORDER_ID', $purchaseUnit, self::SHIPPING_OPTIONS);
+        $response = $this->factory->create('PAYPAL_ORDER_ID', $purchaseUnit, self::shippingOptions());
 
         self::assertSame(
             ['reference_id', 'amount', 'shipping_options'],
@@ -131,7 +137,7 @@ final class PayPalShippingCallbackResponseFactoryTest extends TestCase
 
     public function test_it_omits_a_reference_id_the_request_did_not_carry(): void
     {
-        $response = $this->factory->create('PAYPAL_ORDER_ID', ['amount' => []], self::SHIPPING_OPTIONS);
+        $response = $this->factory->create('PAYPAL_ORDER_ID', ['amount' => []], self::shippingOptions());
 
         self::assertSame(['amount', 'shipping_options'], array_keys($response['purchase_units'][0]));
     }

--- a/tests/Unit/Model/PayPalOrderTest.php
+++ b/tests/Unit/Model/PayPalOrderTest.php
@@ -226,10 +226,6 @@ final class PayPalOrderTest extends TestCase
                     ],
                 ],
             ],
-            'application_context' => [
-                'shipping_preference' => 'GET_FROM_FILE',
-                'user_action' => 'PAY_NOW',
-            ],
             'payment_source' => [
                 'paypal' => [
                     'experience_context' => [
@@ -423,5 +419,18 @@ final class PayPalOrderTest extends TestCase
         $result = $this->payPalOrder->toArray();
 
         self::assertArrayNotHasKey('order_update_callback_config', $result['payment_source']['paypal']['experience_context']);
+    }
+
+    #[Test]
+    public function it_never_sends_both_context_blocks_at_once(): void
+    {
+        $this->order->method('isShippingRequired')->willReturn(true);
+        $this->order->method('getShippingAddress')->willReturn(null);
+        $this->payPalPurchaseUnit->method('toArray')->willReturn([]);
+
+        $result = $this->payPalOrder->toArray();
+
+        self::assertArrayHasKey('payment_source', $result);
+        self::assertArrayNotHasKey('application_context', $result);
     }
 }

--- a/tests/Unit/Model/PayPalOrderTest.php
+++ b/tests/Unit/Model/PayPalOrderTest.php
@@ -394,7 +394,7 @@ final class PayPalOrderTest extends TestCase
             $this->order,
             $this->payPalPurchaseUnit,
             'CAPTURE',
-            shippingCallbackUrl: 'https://shop.example.com/pay-pal-order-shipping-callback',
+            shippingCallbackUrl: 'https://shop.example.com/paypal/order-shipping-callback',
         );
 
         $this->order->method('isShippingRequired')->willReturn(true);
@@ -405,7 +405,7 @@ final class PayPalOrderTest extends TestCase
 
         self::assertSame([
             'callback_events' => ['SHIPPING_ADDRESS'],
-            'callback_url' => 'https://shop.example.com/pay-pal-order-shipping-callback',
+            'callback_url' => 'https://shop.example.com/paypal/order-shipping-callback',
         ], $result['payment_source']['paypal']['experience_context']['order_update_callback_config']);
     }
 

--- a/tests/Unit/Model/PayPalOrderTest.php
+++ b/tests/Unit/Model/PayPalOrderTest.php
@@ -390,4 +390,38 @@ final class PayPalOrderTest extends TestCase
             'cancel_url' => 'https://shop.example.com/checkout/complete',
         ], $result['payment_source']['paypal']['experience_context']);
     }
+
+    #[Test]
+    public function it_declares_the_shipping_callback_on_orders_addressed_in_the_wallet(): void
+    {
+        $payPalOrder = new PayPalOrder(
+            $this->order,
+            $this->payPalPurchaseUnit,
+            'CAPTURE',
+            shippingCallbackUrl: 'https://shop.example.com/pay-pal-order-shipping-callback',
+        );
+
+        $this->order->method('isShippingRequired')->willReturn(true);
+        $this->order->method('getShippingAddress')->willReturn(null);
+        $this->payPalPurchaseUnit->method('toArray')->willReturn([]);
+
+        $result = $payPalOrder->toArray();
+
+        self::assertSame([
+            'callback_events' => ['SHIPPING_ADDRESS'],
+            'callback_url' => 'https://shop.example.com/pay-pal-order-shipping-callback',
+        ], $result['payment_source']['paypal']['experience_context']['order_update_callback_config']);
+    }
+
+    #[Test]
+    public function it_declares_no_shipping_callback_when_it_was_not_given_one(): void
+    {
+        $this->order->method('isShippingRequired')->willReturn(true);
+        $this->order->method('getShippingAddress')->willReturn(null);
+        $this->payPalPurchaseUnit->method('toArray')->willReturn([]);
+
+        $result = $this->payPalOrder->toArray();
+
+        self::assertArrayNotHasKey('order_update_callback_config', $result['payment_source']['paypal']['experience_context']);
+    }
 }

--- a/tests/Unit/Model/PayPalOrderTest.php
+++ b/tests/Unit/Model/PayPalOrderTest.php
@@ -230,6 +230,14 @@ final class PayPalOrderTest extends TestCase
                 'shipping_preference' => 'GET_FROM_FILE',
                 'user_action' => 'PAY_NOW',
             ],
+            'payment_source' => [
+                'paypal' => [
+                    'experience_context' => [
+                        'shipping_preference' => 'GET_FROM_FILE',
+                        'user_action' => 'PAY_NOW',
+                    ],
+                ],
+            ],
         ], $result);
     }
 
@@ -316,5 +324,70 @@ final class PayPalOrderTest extends TestCase
                 'user_action' => 'PAY_NOW',
             ],
         ], $result);
+    }
+
+    #[Test]
+    public function it_selects_the_paypal_payment_source_when_paypal_supplies_the_shipping_address(): void
+    {
+        $this->order->method('isShippingRequired')->willReturn(true);
+        $this->order->method('getShippingAddress')->willReturn(null);
+        $this->payPalPurchaseUnit->method('toArray')->willReturn([]);
+
+        $result = $this->payPalOrder->toArray();
+
+        self::assertSame(
+            ['shipping_preference' => 'GET_FROM_FILE', 'user_action' => 'PAY_NOW'],
+            $result['payment_source']['paypal']['experience_context'],
+        );
+    }
+
+    #[Test]
+    public function it_does_not_select_a_payment_source_when_the_shipping_address_is_already_known(): void
+    {
+        $this->order->method('isShippingRequired')->willReturn(true);
+        $this->order->method('getShippingAddress')->willReturn($this->createMock(AddressInterface::class));
+        $this->payPalPurchaseUnit->method('toArray')->willReturn([]);
+
+        $result = $this->payPalOrder->toArray();
+
+        self::assertSame(['shipping_preference' => 'SET_PROVIDED_ADDRESS', 'user_action' => 'PAY_NOW'], $result['application_context']);
+        self::assertArrayNotHasKey('payment_source', $result);
+    }
+
+    #[Test]
+    public function it_does_not_select_a_payment_source_when_shipping_is_not_required(): void
+    {
+        $this->order->method('isShippingRequired')->willReturn(false);
+        $this->payPalPurchaseUnit->method('toArray')->willReturn([]);
+
+        $result = $this->payPalOrder->toArray();
+
+        self::assertSame(['shipping_preference' => 'NO_SHIPPING', 'user_action' => 'PAY_NOW'], $result['application_context']);
+        self::assertArrayNotHasKey('payment_source', $result);
+    }
+
+    #[Test]
+    public function it_passes_the_return_and_cancel_urls_to_the_experience_context(): void
+    {
+        $payPalOrder = new PayPalOrder(
+            $this->order,
+            $this->payPalPurchaseUnit,
+            'CAPTURE',
+            'https://shop.example.com/checkout/complete',
+            'https://shop.example.com/checkout/complete',
+        );
+
+        $this->order->method('isShippingRequired')->willReturn(true);
+        $this->order->method('getShippingAddress')->willReturn(null);
+        $this->payPalPurchaseUnit->method('toArray')->willReturn([]);
+
+        $result = $payPalOrder->toArray();
+
+        self::assertSame([
+            'shipping_preference' => 'GET_FROM_FILE',
+            'user_action' => 'PAY_NOW',
+            'return_url' => 'https://shop.example.com/checkout/complete',
+            'cancel_url' => 'https://shop.example.com/checkout/complete',
+        ], $result['payment_source']['paypal']['experience_context']);
     }
 }

--- a/tests/Unit/Model/PayPalShippingOptionTest.php
+++ b/tests/Unit/Model/PayPalShippingOptionTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\PayPalPlugin\Unit\Model;
+
+use PHPUnit\Framework\TestCase;
+use Sylius\PayPalPlugin\Model\PayPalShippingOption;
+
+final class PayPalShippingOptionTest extends TestCase
+{
+    public function test_it_shapes_itself_the_way_paypal_reads_shipping_options(): void
+    {
+        $option = new PayPalShippingOption('ups', 'UPS', 'USD', 1000, true);
+
+        self::assertSame([
+            'id' => 'ups',
+            'amount' => ['currency_code' => 'USD', 'value' => '10.00'],
+            'type' => 'SHIPPING',
+            'label' => 'UPS',
+            'selected' => true,
+        ], $option->toArray());
+    }
+
+    public function test_it_is_not_selected_and_ships_rather_than_waits_for_pickup_by_default(): void
+    {
+        $option = new PayPalShippingOption('ups', 'UPS', 'USD', 1000);
+
+        self::assertFalse($option->isSelected());
+        self::assertSame(PayPalShippingOption::TYPE_SHIPPING, $option->type());
+    }
+
+    public function test_it_carries_a_pickup_type_when_it_is_given_one(): void
+    {
+        $option = new PayPalShippingOption('shop', 'Pick up in shop', 'USD', 0, false, PayPalShippingOption::TYPE_PICKUP);
+
+        self::assertSame('PICKUP', $option->toArray()['type']);
+    }
+
+    public function test_it_keeps_the_amount_in_minor_units_and_formats_it_only_for_paypal(): void
+    {
+        $option = new PayPalShippingOption('ups', 'UPS', 'PLN', 1999);
+
+        self::assertSame(1999, $option->amount());
+        self::assertSame(['currency_code' => 'PLN', 'value' => '19.99'], $option->amountToArray());
+    }
+
+    public function test_it_formats_a_free_option_as_zero(): void
+    {
+        $option = new PayPalShippingOption('free', 'Free shipping', 'EUR', 0);
+
+        self::assertSame(['currency_code' => 'EUR', 'value' => '0.00'], $option->amountToArray());
+    }
+
+    public function test_it_hands_back_a_copy_when_its_selection_changes(): void
+    {
+        $option = new PayPalShippingOption('ups', 'UPS', 'USD', 1000);
+
+        $selected = $option->withSelected(true);
+
+        self::assertFalse($option->isSelected());
+        self::assertTrue($selected->isSelected());
+        self::assertSame(
+            ['ups', 'UPS', 'USD', 1000],
+            [$selected->id(), $selected->label(), $selected->currencyCode(), $selected->amount()],
+        );
+    }
+}

--- a/tests/Unit/Payum/Action/CaptureActionTest.php
+++ b/tests/Unit/Payum/Action/CaptureActionTest.php
@@ -90,6 +90,55 @@ final class CaptureActionTest extends TestCase
     }
 
     #[Test]
+    public function it_sets_order_response_data_on_payment_when_paypal_asks_for_a_payer_action(): void
+    {
+        $request = $this->createMock(Capture::class);
+        $payment = $this->createMock(PaymentInterface::class);
+        $paymentMethod = $this->createMock(PaymentMethodInterface::class);
+        $order = $this->createMock(OrderInterface::class);
+
+        $request->method('getModel')->willReturn($payment);
+        $payment->method('getMethod')->willReturn($paymentMethod);
+        $payment->method('getAmount')->willReturn(1000);
+        $payment->method('getOrder')->willReturn($order);
+        $order->method('getCurrencyCode')->willReturn('USD');
+
+        $this->uuidProvider->method('provide')->willReturn('UUID');
+
+        $this->authorizeClientApi->method('authorize')->with($paymentMethod)->willReturn('ACCESS_TOKEN');
+        $this->createOrderApi->method('create')->with('ACCESS_TOKEN', $payment, 'UUID')->willReturn(['status' => 'PAYER_ACTION_REQUIRED', 'id' => '123123']);
+
+        $payment->expects(self::once())->method('setDetails')->with([
+            'status' => StatusAction::STATUS_CAPTURED,
+            'paypal_order_id' => '123123',
+            'reference_id' => 'UUID',
+            'payment_amount' => 1000,
+        ]);
+
+        $this->captureAction->execute($request);
+    }
+
+    #[Test]
+    public function it_does_not_set_order_response_data_on_payment_when_paypal_does_not_confirm_the_order(): void
+    {
+        $request = $this->createMock(Capture::class);
+        $payment = $this->createMock(PaymentInterface::class);
+        $paymentMethod = $this->createMock(PaymentMethodInterface::class);
+
+        $request->method('getModel')->willReturn($payment);
+        $payment->method('getMethod')->willReturn($paymentMethod);
+
+        $this->uuidProvider->method('provide')->willReturn('UUID');
+
+        $this->authorizeClientApi->method('authorize')->with($paymentMethod)->willReturn('ACCESS_TOKEN');
+        $this->createOrderApi->method('create')->with('ACCESS_TOKEN', $payment, 'UUID')->willReturn(['name' => 'UNPROCESSABLE_ENTITY']);
+
+        $payment->expects(self::never())->method('setDetails');
+
+        $this->captureAction->execute($request);
+    }
+
+    #[Test]
     public function it_throws_an_exception_if_request_type_is_invalid(): void
     {
         $request = $this->createMock(Authorize::class);

--- a/tests/Unit/Payum/Action/CaptureActionTest.php
+++ b/tests/Unit/Payum/Action/CaptureActionTest.php
@@ -28,6 +28,8 @@ use Sylius\PayPalPlugin\Api\CacheAuthorizeClientApiInterface;
 use Sylius\PayPalPlugin\Api\CreateOrderApiInterface;
 use Sylius\PayPalPlugin\Payum\Action\CaptureAction;
 use Sylius\PayPalPlugin\Payum\Action\StatusAction;
+use Sylius\PayPalPlugin\Provider\PayPalOrderCreatedStatusesProvider;
+use Sylius\PayPalPlugin\Provider\PayPalOrderCreatedStatusesProviderInterface;
 use Sylius\PayPalPlugin\Provider\UuidProviderInterface;
 
 final class CaptureActionTest extends TestCase
@@ -51,6 +53,7 @@ final class CaptureActionTest extends TestCase
             $this->authorizeClientApi,
             $this->createOrderApi,
             $this->uuidProvider,
+            new PayPalOrderCreatedStatusesProvider(),
         );
     }
 
@@ -136,6 +139,34 @@ final class CaptureActionTest extends TestCase
         $payment->expects(self::never())->method('setDetails');
 
         $this->captureAction->execute($request);
+    }
+
+    #[Test]
+    public function it_treats_as_created_only_the_statuses_its_provider_names(): void
+    {
+        $orderCreatedStatusesProvider = $this->createMock(PayPalOrderCreatedStatusesProviderInterface::class);
+        $orderCreatedStatusesProvider->method('provide')->willReturn(['SOME_OTHER_STATUS']);
+
+        $captureAction = new CaptureAction(
+            $this->authorizeClientApi,
+            $this->createOrderApi,
+            $this->uuidProvider,
+            $orderCreatedStatusesProvider,
+        );
+
+        $request = $this->createMock(Capture::class);
+        $payment = $this->createMock(PaymentInterface::class);
+        $paymentMethod = $this->createMock(PaymentMethodInterface::class);
+
+        $request->method('getModel')->willReturn($payment);
+        $payment->method('getMethod')->willReturn($paymentMethod);
+        $this->authorizeClientApi->method('authorize')->with($paymentMethod)->willReturn('ACCESS_TOKEN');
+        $this->uuidProvider->method('provide')->willReturn('UUID');
+        $this->createOrderApi->method('create')->willReturn(['status' => 'CREATED', 'id' => '123123']);
+
+        $payment->expects(self::never())->method('setDetails');
+
+        $captureAction->execute($request);
     }
 
     #[Test]

--- a/tests/Unit/Provider/PayPalOrderCreatedStatusesProviderTest.php
+++ b/tests/Unit/Provider/PayPalOrderCreatedStatusesProviderTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\PayPalPlugin\Unit\Provider;
+
+use PHPUnit\Framework\TestCase;
+use Sylius\PayPalPlugin\Provider\PayPalOrderCreatedStatusesProvider;
+use Sylius\PayPalPlugin\Provider\PayPalOrderCreatedStatusesProviderInterface;
+
+final class PayPalOrderCreatedStatusesProviderTest extends TestCase
+{
+    private PayPalOrderCreatedStatusesProvider $provider;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->provider = new PayPalOrderCreatedStatusesProvider();
+    }
+
+    public function test_it_implements_paypal_order_created_statuses_provider_interface(): void
+    {
+        self::assertInstanceOf(PayPalOrderCreatedStatusesProviderInterface::class, $this->provider);
+    }
+
+    public function test_it_names_both_statuses_paypal_answers_a_created_order_with(): void
+    {
+        self::assertSame(['CREATED', 'PAYER_ACTION_REQUIRED'], $this->provider->provide());
+    }
+}

--- a/tests/Unit/Provider/PayPalShippingCallbackUrlProviderTest.php
+++ b/tests/Unit/Provider/PayPalShippingCallbackUrlProviderTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\PayPalPlugin\Unit\Provider;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\PayPalPlugin\Provider\PayPalShippingCallbackUrlProvider;
+use Sylius\PayPalPlugin\Provider\PayPalShippingCallbackUrlProviderInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class PayPalShippingCallbackUrlProviderTest extends TestCase
+{
+    private UrlGeneratorInterface&MockObject $router;
+
+    private PayPalShippingCallbackUrlProvider $provider;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->router = $this->createMock(UrlGeneratorInterface::class);
+
+        $this->provider = new PayPalShippingCallbackUrlProvider($this->router);
+    }
+
+    public function test_it_implements_paypal_shipping_callback_url_provider_interface(): void
+    {
+        self::assertInstanceOf(PayPalShippingCallbackUrlProviderInterface::class, $this->provider);
+    }
+
+    public function test_it_generates_the_shipping_callback_route_as_an_absolute_url(): void
+    {
+        $this->router
+            ->expects(self::once())
+            ->method('generate')
+            ->with('sylius_paypal_shop_order_shipping_callback', [], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('https://shop.example.com/pay-pal-order-shipping-callback')
+        ;
+
+        self::assertSame('https://shop.example.com/pay-pal-order-shipping-callback', $this->provider->provide());
+    }
+
+    public function test_it_provides_no_url_paypal_could_not_reach(): void
+    {
+        $this->router->method('generate')->willReturn('http://shop.example.com/pay-pal-order-shipping-callback');
+
+        self::assertNull($this->provider->provide());
+    }
+
+    public function test_it_generates_the_route_it_is_given(): void
+    {
+        $this->router
+            ->expects(self::once())
+            ->method('generate')
+            ->with('other_route', [], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('https://shop.example.com/other')
+        ;
+
+        self::assertSame('https://shop.example.com/other', (new PayPalShippingCallbackUrlProvider(
+            $this->router,
+            'other_route',
+        ))->provide());
+    }
+}

--- a/tests/Unit/Provider/PayPalShippingCallbackUrlProviderTest.php
+++ b/tests/Unit/Provider/PayPalShippingCallbackUrlProviderTest.php
@@ -43,16 +43,19 @@ final class PayPalShippingCallbackUrlProviderTest extends TestCase
         $this->router
             ->expects(self::once())
             ->method('generate')
-            ->with('sylius_paypal_shop_order_shipping_callback', [], UrlGeneratorInterface::ABSOLUTE_URL)
-            ->willReturn('https://shop.example.com/pay-pal-order-shipping-callback')
+            ->with('sylius_paypal_order_shipping_callback', [], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('https://shop.example.com/paypal/order-shipping-callback')
         ;
 
-        self::assertSame('https://shop.example.com/pay-pal-order-shipping-callback', $this->provider->provide());
+        self::assertSame(
+            'https://shop.example.com/paypal/order-shipping-callback',
+            $this->provider->provide(),
+        );
     }
 
     public function test_it_provides_no_url_paypal_could_not_reach(): void
     {
-        $this->router->method('generate')->willReturn('http://shop.example.com/pay-pal-order-shipping-callback');
+        $this->router->method('generate')->willReturn('http://shop.example.com/paypal/order-shipping-callback');
 
         self::assertNull($this->provider->provide());
     }

--- a/tests/Unit/Resolver/PayPalShippingAddressResolverTest.php
+++ b/tests/Unit/Resolver/PayPalShippingAddressResolverTest.php
@@ -83,13 +83,24 @@ final class PayPalShippingAddressResolverTest extends TestCase
         self::assertSame('TX', $address->getProvinceCode());
     }
 
-    public function test_it_drops_a_region_that_matches_no_known_province(): void
+    public function test_it_keeps_a_region_that_matches_no_known_province_as_free_text(): void
     {
         $this->provinceRepository->method('findOneBy')->willReturn(null);
 
         $address = $this->resolver->resolve(['country_code' => 'PL', 'admin_area_1' => 'Mazowieckie']);
 
         self::assertNull($address->getProvinceCode());
+        self::assertSame('Mazowieckie', $address->getProvinceName());
+    }
+
+    public function test_it_leaves_the_region_name_out_once_it_resolves_to_a_province(): void
+    {
+        $this->provinceRepository->method('findOneBy')->willReturn($this->createMock(ProvinceInterface::class));
+
+        $address = $this->resolver->resolve(['country_code' => 'US', 'admin_area_1' => 'TX']);
+
+        self::assertSame('US-TX', $address->getProvinceCode());
+        self::assertNull($address->getProvinceName());
     }
 
     public function test_it_leaves_out_the_parts_paypal_did_not_send(): void
@@ -102,6 +113,7 @@ final class PayPalShippingAddressResolverTest extends TestCase
         self::assertNull($address->getCity());
         self::assertNull($address->getPostcode());
         self::assertNull($address->getProvinceCode());
+        self::assertNull($address->getProvinceName());
     }
 
     public function test_it_treats_blank_values_as_absent(): void
@@ -118,5 +130,6 @@ final class PayPalShippingAddressResolverTest extends TestCase
         self::assertNull($address->getCity());
         self::assertNull($address->getPostcode());
         self::assertNull($address->getProvinceCode());
+        self::assertNull($address->getProvinceName());
     }
 }

--- a/tests/Unit/Resolver/PayPalShippingAddressResolverTest.php
+++ b/tests/Unit/Resolver/PayPalShippingAddressResolverTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\PayPalPlugin\Unit\Resolver;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Addressing\Model\ProvinceInterface;
+use Sylius\Component\Core\Factory\AddressFactoryInterface;
+use Sylius\Component\Core\Model\Address;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Sylius\PayPalPlugin\Resolver\PayPalShippingAddressResolver;
+use Sylius\PayPalPlugin\Resolver\PayPalShippingAddressResolverInterface;
+
+final class PayPalShippingAddressResolverTest extends TestCase
+{
+    private AddressFactoryInterface&MockObject $addressFactory;
+
+    private RepositoryInterface&MockObject $provinceRepository;
+
+    private PayPalShippingAddressResolver $resolver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->addressFactory = $this->createMock(AddressFactoryInterface::class);
+        $this->provinceRepository = $this->createMock(RepositoryInterface::class);
+        $this->addressFactory->method('createNew')->willReturnCallback(fn (): Address => new Address());
+
+        $this->resolver = new PayPalShippingAddressResolver($this->addressFactory, $this->provinceRepository);
+    }
+
+    public function test_it_implements_paypal_shipping_address_resolver_interface(): void
+    {
+        self::assertInstanceOf(PayPalShippingAddressResolverInterface::class, $this->resolver);
+    }
+
+    public function test_it_maps_the_redacted_address_paypal_sends(): void
+    {
+        $this->provinceRepository->method('findOneBy')->willReturn(null);
+
+        $address = $this->resolver->resolve([
+            'country_code' => 'US',
+            'admin_area_1' => 'TX',
+            'admin_area_2' => 'Dallas',
+            'postal_code' => '75001',
+        ]);
+
+        self::assertSame('US', $address->getCountryCode());
+        self::assertSame('Dallas', $address->getCity());
+        self::assertSame('75001', $address->getPostcode());
+    }
+
+    public function test_it_prefixes_the_region_with_the_country_when_that_province_is_known(): void
+    {
+        $province = $this->createMock(ProvinceInterface::class);
+        $this->provinceRepository->expects(self::once())->method('findOneBy')->with(['code' => 'US-TX'])->willReturn($province);
+
+        $address = $this->resolver->resolve(['country_code' => 'US', 'admin_area_1' => 'TX']);
+
+        self::assertSame('US-TX', $address->getProvinceCode());
+    }
+
+    public function test_it_falls_back_to_the_bare_region_when_only_that_province_is_known(): void
+    {
+        $province = $this->createMock(ProvinceInterface::class);
+        $this->provinceRepository
+            ->method('findOneBy')
+            ->willReturnCallback(fn (array $criteria): ?ProvinceInterface => $criteria === ['code' => 'TX'] ? $province : null);
+
+        $address = $this->resolver->resolve(['country_code' => 'US', 'admin_area_1' => 'TX']);
+
+        self::assertSame('TX', $address->getProvinceCode());
+    }
+
+    public function test_it_drops_a_region_that_matches_no_known_province(): void
+    {
+        $this->provinceRepository->method('findOneBy')->willReturn(null);
+
+        $address = $this->resolver->resolve(['country_code' => 'PL', 'admin_area_1' => 'Mazowieckie']);
+
+        self::assertNull($address->getProvinceCode());
+    }
+
+    public function test_it_leaves_out_the_parts_paypal_did_not_send(): void
+    {
+        $this->provinceRepository->expects(self::never())->method('findOneBy');
+
+        $address = $this->resolver->resolve(['country_code' => 'DE']);
+
+        self::assertSame('DE', $address->getCountryCode());
+        self::assertNull($address->getCity());
+        self::assertNull($address->getPostcode());
+        self::assertNull($address->getProvinceCode());
+    }
+
+    public function test_it_treats_blank_values_as_absent(): void
+    {
+        $this->provinceRepository->expects(self::never())->method('findOneBy');
+
+        $address = $this->resolver->resolve([
+            'country_code' => 'DE',
+            'admin_area_1' => '   ',
+            'admin_area_2' => '',
+            'postal_code' => ' ',
+        ]);
+
+        self::assertNull($address->getCity());
+        self::assertNull($address->getPostcode());
+        self::assertNull($address->getProvinceCode());
+    }
+}

--- a/tests/Unit/Resolver/PayPalShippingOptionsResolverTest.php
+++ b/tests/Unit/Resolver/PayPalShippingOptionsResolverTest.php
@@ -22,6 +22,7 @@ use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Shipping\Calculator\DelegatingCalculatorInterface;
 use Sylius\Component\Shipping\Model\ShippingMethodInterface;
 use Sylius\Component\Shipping\Resolver\ShippingMethodsResolverInterface;
+use Sylius\PayPalPlugin\Model\PayPalShippingOption;
 use Sylius\PayPalPlugin\Resolver\PayPalShippingOptionsResolver;
 use Sylius\PayPalPlugin\Resolver\PayPalShippingOptionsResolverInterface;
 
@@ -79,10 +80,22 @@ final class PayPalShippingOptionsResolverTest extends TestCase
 
         $options = $this->resolver->resolve($this->order, $this->shippingAddress);
 
+        self::assertContainsOnlyInstancesOf(PayPalShippingOption::class, $options);
         self::assertSame([
             ['id' => 'ups', 'amount' => ['currency_code' => 'USD', 'value' => '10.00'], 'type' => 'SHIPPING', 'label' => 'UPS', 'selected' => true],
             ['id' => 'dhl', 'amount' => ['currency_code' => 'USD', 'value' => '25.50'], 'type' => 'SHIPPING', 'label' => 'DHL', 'selected' => false],
-        ], $options);
+        ], array_map(static fn (PayPalShippingOption $option): array => $option->toArray(), $options));
+    }
+
+    public function test_it_keeps_the_shipping_cost_in_minor_units(): void
+    {
+        $this->shippingMethodsResolver->method('getSupportedMethods')->willReturn([$this->shippingMethod('ups', 'UPS')]);
+        $this->shippingCalculator->method('calculate')->willReturn(1999);
+
+        $options = $this->resolver->resolve($this->order, $this->shippingAddress);
+
+        self::assertSame(1999, $options[0]->amount());
+        self::assertSame('USD', $options[0]->currencyCode());
     }
 
     public function test_it_keeps_the_method_the_order_already_carries_selected(): void
@@ -96,7 +109,10 @@ final class PayPalShippingOptionsResolverTest extends TestCase
 
         $options = $this->resolver->resolve($this->order, $this->shippingAddress);
 
-        self::assertSame([false, true], array_column($options, 'selected'));
+        self::assertSame([false, true], array_map(
+            static fn (PayPalShippingOption $option): bool => $option->isSelected(),
+            $options,
+        ));
     }
 
     public function test_it_selects_the_cheapest_option_when_the_current_method_is_no_longer_offered(): void
@@ -109,7 +125,10 @@ final class PayPalShippingOptionsResolverTest extends TestCase
 
         $options = $this->resolver->resolve($this->order, $this->shippingAddress);
 
-        self::assertSame([false, true], array_column($options, 'selected'));
+        self::assertSame([false, true], array_map(
+            static fn (PayPalShippingOption $option): bool => $option->isSelected(),
+            $options,
+        ));
     }
 
     public function test_it_puts_the_borrowed_address_and_method_back_on_the_order(): void

--- a/tests/Unit/Resolver/PayPalShippingOptionsResolverTest.php
+++ b/tests/Unit/Resolver/PayPalShippingOptionsResolverTest.php
@@ -1,0 +1,169 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\PayPalPlugin\Unit\Resolver;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Core\Model\AddressInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\ShipmentInterface;
+use Sylius\Component\Shipping\Calculator\DelegatingCalculatorInterface;
+use Sylius\Component\Shipping\Model\ShippingMethodInterface;
+use Sylius\Component\Shipping\Resolver\ShippingMethodsResolverInterface;
+use Sylius\PayPalPlugin\Resolver\PayPalShippingOptionsResolver;
+use Sylius\PayPalPlugin\Resolver\PayPalShippingOptionsResolverInterface;
+
+final class PayPalShippingOptionsResolverTest extends TestCase
+{
+    private ShippingMethodsResolverInterface&MockObject $shippingMethodsResolver;
+
+    private DelegatingCalculatorInterface&MockObject $shippingCalculator;
+
+    private OrderInterface&MockObject $order;
+
+    private ShipmentInterface&MockObject $shipment;
+
+    private AddressInterface&MockObject $shippingAddress;
+
+    private PayPalShippingOptionsResolver $resolver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->shippingMethodsResolver = $this->createMock(ShippingMethodsResolverInterface::class);
+        $this->shippingCalculator = $this->createMock(DelegatingCalculatorInterface::class);
+        $this->order = $this->createMock(OrderInterface::class);
+        $this->shipment = $this->createMock(ShipmentInterface::class);
+        $this->shippingAddress = $this->createMock(AddressInterface::class);
+
+        $this->order->method('getCurrencyCode')->willReturn('USD');
+        $this->order->method('getShipments')->willReturn(new ArrayCollection([$this->shipment]));
+
+        $this->resolver = new PayPalShippingOptionsResolver($this->shippingMethodsResolver, $this->shippingCalculator);
+    }
+
+    public function test_it_implements_paypal_shipping_options_resolver_interface(): void
+    {
+        self::assertInstanceOf(PayPalShippingOptionsResolverInterface::class, $this->resolver);
+    }
+
+    public function test_it_returns_no_options_when_the_order_has_no_shipment(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getShipments')->willReturn(new ArrayCollection());
+
+        $this->shippingMethodsResolver->expects(self::never())->method('getSupportedMethods');
+
+        self::assertSame([], $this->resolver->resolve($order, $this->shippingAddress));
+    }
+
+    public function test_it_prices_every_method_supported_for_the_given_address(): void
+    {
+        $this->shippingMethodsResolver
+            ->method('getSupportedMethods')
+            ->with($this->shipment)
+            ->willReturn([$this->shippingMethod('ups', 'UPS'), $this->shippingMethod('dhl', 'DHL')]);
+        $this->shippingCalculator->method('calculate')->willReturnOnConsecutiveCalls(1000, 2550);
+
+        $options = $this->resolver->resolve($this->order, $this->shippingAddress);
+
+        self::assertSame([
+            ['id' => 'ups', 'amount' => ['currency_code' => 'USD', 'value' => '10.00'], 'type' => 'SHIPPING', 'label' => 'UPS', 'selected' => true],
+            ['id' => 'dhl', 'amount' => ['currency_code' => 'USD', 'value' => '25.50'], 'type' => 'SHIPPING', 'label' => 'DHL', 'selected' => false],
+        ], $options);
+    }
+
+    public function test_it_keeps_the_method_the_order_already_carries_selected(): void
+    {
+        $ups = $this->shippingMethod('ups', 'UPS');
+        $dhl = $this->shippingMethod('dhl', 'DHL');
+
+        $this->shipment->method('getMethod')->willReturn($dhl);
+        $this->shippingMethodsResolver->method('getSupportedMethods')->willReturn([$ups, $dhl]);
+        $this->shippingCalculator->method('calculate')->willReturnOnConsecutiveCalls(1000, 2550);
+
+        $options = $this->resolver->resolve($this->order, $this->shippingAddress);
+
+        self::assertSame([false, true], array_column($options, 'selected'));
+    }
+
+    public function test_it_selects_the_cheapest_option_when_the_current_method_is_no_longer_offered(): void
+    {
+        $this->shipment->method('getMethod')->willReturn($this->shippingMethod('fedex', 'FedEx'));
+        $this->shippingMethodsResolver
+            ->method('getSupportedMethods')
+            ->willReturn([$this->shippingMethod('ups', 'UPS'), $this->shippingMethod('dhl', 'DHL')]);
+        $this->shippingCalculator->method('calculate')->willReturnOnConsecutiveCalls(2550, 1000);
+
+        $options = $this->resolver->resolve($this->order, $this->shippingAddress);
+
+        self::assertSame([false, true], array_column($options, 'selected'));
+    }
+
+    public function test_it_puts_the_borrowed_address_and_method_back_on_the_order(): void
+    {
+        $originalAddress = $this->createMock(AddressInterface::class);
+        $originalMethod = $this->shippingMethod('fedex', 'FedEx');
+        $offeredMethod = $this->shippingMethod('ups', 'UPS');
+
+        $this->order->method('getShippingAddress')->willReturn($originalAddress);
+        $this->shipment->method('getMethod')->willReturn($originalMethod);
+        $this->shippingMethodsResolver->method('getSupportedMethods')->willReturn([$offeredMethod]);
+        $this->shippingCalculator->method('calculate')->willReturn(1000);
+
+        $assignedAddresses = [];
+        $this->order->method('setShippingAddress')->willReturnCallback(
+            function (?AddressInterface $address) use (&$assignedAddresses): void {
+                $assignedAddresses[] = $address;
+            },
+        );
+
+        $assignedMethods = [];
+        $this->shipment->method('setMethod')->willReturnCallback(
+            function (?ShippingMethodInterface $method) use (&$assignedMethods): void {
+                $assignedMethods[] = $method;
+            },
+        );
+
+        $this->resolver->resolve($this->order, $this->shippingAddress);
+
+        self::assertSame([$this->shippingAddress, $originalAddress], $assignedAddresses);
+        self::assertSame([$offeredMethod, $originalMethod], $assignedMethods);
+    }
+
+    public function test_it_puts_them_back_even_when_pricing_blows_up(): void
+    {
+        $originalAddress = $this->createMock(AddressInterface::class);
+
+        $this->order->method('getShippingAddress')->willReturn($originalAddress);
+        $this->shippingMethodsResolver->method('getSupportedMethods')->willReturn([$this->shippingMethod('ups', 'UPS')]);
+        $this->shippingCalculator->method('calculate')->willThrowException(new \RuntimeException('no calculator'));
+
+        $this->order->expects(self::exactly(2))->method('setShippingAddress');
+
+        $this->expectException(\RuntimeException::class);
+
+        $this->resolver->resolve($this->order, $this->shippingAddress);
+    }
+
+    private function shippingMethod(string $code, string $name): ShippingMethodInterface&MockObject
+    {
+        $method = $this->createMock(ShippingMethodInterface::class);
+        $method->method('getCode')->willReturn($code);
+        $method->method('getName')->willReturn($name);
+
+        return $method;
+    }
+}

--- a/tests/Unit/Resolver/PayPalShippingOptionsResolverTest.php
+++ b/tests/Unit/Resolver/PayPalShippingOptionsResolverTest.php
@@ -21,6 +21,7 @@ use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Shipping\Calculator\DelegatingCalculatorInterface;
 use Sylius\Component\Shipping\Model\ShippingMethodInterface;
+use Sylius\Component\Shipping\Model\ShippingMethodTranslationInterface;
 use Sylius\Component\Shipping\Resolver\ShippingMethodsResolverInterface;
 use Sylius\PayPalPlugin\Model\PayPalShippingOption;
 use Sylius\PayPalPlugin\Resolver\PayPalShippingOptionsResolver;
@@ -177,6 +178,56 @@ final class PayPalShippingOptionsResolverTest extends TestCase
         $this->resolver->resolve($this->order, $this->shippingAddress);
     }
 
+    public function test_it_labels_the_option_with_the_method_name_in_the_locale_of_the_order(): void
+    {
+        $this->order->method('getLocaleCode')->willReturn('pl_PL');
+
+        $method = $this->shippingMethod('ups', 'UPS');
+        $method
+            ->expects(self::once())
+            ->method('getTranslation')
+            ->with('pl_PL')
+            ->willReturn($this->translation('Kurier UPS'))
+        ;
+
+        $this->shippingMethodsResolver->method('getSupportedMethods')->willReturn([$method]);
+        $this->shippingCalculator->method('calculate')->willReturn(1000);
+
+        $options = $this->resolver->resolve($this->order, $this->shippingAddress);
+
+        self::assertSame('Kurier UPS', $options[0]->label());
+    }
+
+    public function test_it_falls_back_to_the_loaded_name_when_the_order_carries_no_locale(): void
+    {
+        $this->order->method('getLocaleCode')->willReturn(null);
+
+        $method = $this->shippingMethod('ups', 'UPS');
+        $method->expects(self::never())->method('getTranslation');
+
+        $this->shippingMethodsResolver->method('getSupportedMethods')->willReturn([$method]);
+        $this->shippingCalculator->method('calculate')->willReturn(1000);
+
+        $options = $this->resolver->resolve($this->order, $this->shippingAddress);
+
+        self::assertSame('UPS', $options[0]->label());
+    }
+
+    public function test_it_falls_back_to_the_loaded_name_when_that_locale_has_no_translation(): void
+    {
+        $this->order->method('getLocaleCode')->willReturn('pl_PL');
+
+        $method = $this->shippingMethod('ups', 'UPS');
+        $method->method('getTranslation')->with('pl_PL')->willReturn($this->translation(null));
+
+        $this->shippingMethodsResolver->method('getSupportedMethods')->willReturn([$method]);
+        $this->shippingCalculator->method('calculate')->willReturn(1000);
+
+        $options = $this->resolver->resolve($this->order, $this->shippingAddress);
+
+        self::assertSame('UPS', $options[0]->label());
+    }
+
     private function shippingMethod(string $code, string $name): ShippingMethodInterface&MockObject
     {
         $method = $this->createMock(ShippingMethodInterface::class);
@@ -184,5 +235,13 @@ final class PayPalShippingOptionsResolverTest extends TestCase
         $method->method('getName')->willReturn($name);
 
         return $method;
+    }
+
+    private function translation(?string $name): ShippingMethodTranslationInterface&MockObject
+    {
+        $translation = $this->createMock(ShippingMethodTranslationInterface::class);
+        $translation->method('getName')->willReturn($name);
+
+        return $translation;
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | phase-1
| Bug fix?        | no
| New feature?    | yes
| Related tickets | 

The cart and product ("shortcut") placements reach PayPal without a shipping address, so the buyer picks one in the wallet. Until now that address was priced by a client-side handler that wrote a placeholder address (`Temp`/`Temp`/`Temp`) onto the real order and sent PayPal a single, default shipping method — and PayPal's health check reported no shipping-callback endpoint invoked in twelve months.

PayPal now calls a server-side endpoint instead (`POST /pay-pal-order-shipping-callback`), which answers with every shipping method eligible for that address and its price, or a `422` naming the reason the order cannot be shipped there. Nothing is written to the order — the buyer has approved nothing yet. The method they pick is applied to the Sylius order on approval, along with the region, which was previously dropped.

Two resolvers carry the work and are open for decoration: `PayPalShippingOptionsResolverInterface` and `PayPalShippingAddressResolverInterface`. Both build on stock Sylius services, so the wallet offers the same methods and prices the normal checkout does.
