### PR TITLE
Add PayLater & Venmo button

### DIFF
--- a/assets/shop/controllers/PaypalWebSdkController.js
+++ b/assets/shop/controllers/PaypalWebSdkController.js
@@ -1,7 +1,7 @@
 import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
-    static targets = ['paypalButton', 'payLaterButton'];
+    static targets = ['paypalButton', 'payLaterButton', 'venmoButton'];
 
     static values = {
         scriptUrl: String,
@@ -14,6 +14,7 @@ export default class extends Controller {
         errorUrl: String,
         loadingSelector: String,
         payLaterEnabled: Boolean,
+        venmoEnabled: Boolean,
     };
 
     syliusOrderId = null;
@@ -44,6 +45,10 @@ export default class extends Controller {
                 this.payLaterButtonTarget.productCode = payLaterDetails.productCode;
                 this.payLaterButtonTarget.countryCode = payLaterDetails.countryCode;
                 this.wireUpButton(this.payLaterButtonTarget, sdkInstance.createPayLaterOneTimePaymentSession(this.buildSessionOptions()));
+            }
+
+            if (this.venmoEnabledValue && this.hasVenmoButtonTarget && paymentMethods.isEligible('venmo')) {
+                this.wireUpButton(this.venmoButtonTarget, sdkInstance.createVenmoOneTimePaymentSession(this.buildSessionOptions()));
             }
         } catch (error) {
             console.error('PayPal Web SDK initialization error:', error);

--- a/assets/shop/controllers/PaypalWebSdkController.js
+++ b/assets/shop/controllers/PaypalWebSdkController.js
@@ -1,7 +1,7 @@
 import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
-    static targets = ['paypalButton'];
+    static targets = ['paypalButton', 'payLaterButton'];
 
     static values = {
         scriptUrl: String,
@@ -13,6 +13,7 @@ export default class extends Controller {
         cancelOrderUrl: String,
         errorUrl: String,
         loadingSelector: String,
+        payLaterEnabled: Boolean,
     };
 
     syliusOrderId = null;
@@ -33,27 +34,39 @@ export default class extends Controller {
             });
 
             const paymentMethods = await sdkInstance.findEligibleMethods({ currencyCode: this.currencyCodeValue });
-            if (!paymentMethods.isEligible('paypal')) {
-                return;
+
+            if (paymentMethods.isEligible('paypal')) {
+                this.wireUpButton(this.paypalButtonTarget, sdkInstance.createPayPalOneTimePaymentSession(this.buildSessionOptions()));
             }
 
-            const paymentSession = sdkInstance.createPayPalOneTimePaymentSession({
-                onApprove: this.onApprove.bind(this),
-                onCancel: this.onCancel.bind(this),
-                onError: this.onError.bind(this),
-            });
-
-            this.paypalButtonTarget.removeAttribute('hidden');
-            this.paypalButtonTarget.addEventListener('click', async () => {
-                try {
-                    await paymentSession.start({ presentationMode: 'auto' }, this.createOrder());
-                } catch (error) {
-                    console.error('paymentSession.start() failed:', error);
-                }
-            });
+            if (this.payLaterEnabledValue && this.hasPayLaterButtonTarget && paymentMethods.isEligible('paylater')) {
+                const payLaterDetails = paymentMethods.getDetails('paylater');
+                this.payLaterButtonTarget.productCode = payLaterDetails.productCode;
+                this.payLaterButtonTarget.countryCode = payLaterDetails.countryCode;
+                this.wireUpButton(this.payLaterButtonTarget, sdkInstance.createPayLaterOneTimePaymentSession(this.buildSessionOptions()));
+            }
         } catch (error) {
             console.error('PayPal Web SDK initialization error:', error);
         }
+    }
+
+    buildSessionOptions() {
+        return {
+            onApprove: this.onApprove.bind(this),
+            onCancel: this.onCancel.bind(this),
+            onError: this.onError.bind(this),
+        };
+    }
+
+    wireUpButton(buttonTarget, paymentSession) {
+        buttonTarget.removeAttribute('hidden');
+        buttonTarget.addEventListener('click', async () => {
+            try {
+                await paymentSession.start({ presentationMode: 'auto' }, this.createOrder());
+            } catch (error) {
+                console.error('paymentSession.start() failed:', error);
+            }
+        });
     }
 
     loadWebSdkOnce() {

--- a/assets/shop/controllers/PaypalWebSdkController.js
+++ b/assets/shop/controllers/PaypalWebSdkController.js
@@ -7,6 +7,7 @@ export default class extends Controller {
         scriptUrl: String,
         instanceConfig: Object,
         currencyCode: String,
+        amount: String,
         createOrderUrl: String,
         addToCartFormSelector: String,
         captureOrderUrl: String,
@@ -32,9 +33,14 @@ export default class extends Controller {
                 components: this.instanceConfigValue.components,
                 pageType: this.instanceConfigValue.pageType,
                 partnerAttributionId: this.instanceConfigValue.partnerAttributionId,
+                testBuyerCountry: this.instanceConfigValue.testBuyerCountry,
             });
 
-            const paymentMethods = await sdkInstance.findEligibleMethods({ currencyCode: this.currencyCodeValue });
+            const eligibilityRequest = { currencyCode: this.currencyCodeValue };
+            if (this.hasAmountValue && this.amountValue !== '') {
+                eligibilityRequest.amount = this.amountValue;
+            }
+            const paymentMethods = await sdkInstance.findEligibleMethods(eligibilityRequest);
 
             if (paymentMethods.isEligible('paypal')) {
                 this.wireUpButton(this.paypalButtonTarget, sdkInstance.createPayPalOneTimePaymentSession(this.buildSessionOptions()));

--- a/config/app/twig_hooks/admin/payment_method/update.yaml
+++ b/config/app/twig_hooks/admin/payment_method/update.yaml
@@ -18,3 +18,12 @@ sylius_twig_hooks:
             reports_sftp_password:
                 template: '@SyliusPayPalPlugin/admin/payment_method/form/section/gateway_configuration/reports_sftp_password.html.twig'
                 priority: -400
+            paylater_enabled:
+                template: '@SyliusPayPalPlugin/admin/payment_method/form/section/gateway_configuration/paylater_enabled.html.twig'
+                priority: -500
+            venmo_enabled:
+                template: '@SyliusPayPalPlugin/admin/payment_method/form/section/gateway_configuration/venmo_enabled.html.twig'
+                priority: -600
+            messaging_enabled:
+                template: '@SyliusPayPalPlugin/admin/payment_method/form/section/gateway_configuration/messaging_enabled.html.twig'
+                priority: -700

--- a/config/app/twig_hooks/shop/cart/index.yaml
+++ b/config/app/twig_hooks/shop/cart/index.yaml
@@ -4,3 +4,6 @@ sylius_twig_hooks:
             paypal_checkout:
                 template: '@SyliusPayPalPlugin/shop/cart/index/content/form/sections/general/paypal_checkout.html.twig'
                 priority: -100
+            paypal_messaging:
+                template: '@SyliusPayPalPlugin/shop/cart/index/content/form/sections/general/paypal_messaging.html.twig'
+                priority: -200

--- a/config/app/twig_hooks/shop/checkout/select_payment.yaml
+++ b/config/app/twig_hooks/shop/checkout/select_payment.yaml
@@ -4,3 +4,6 @@ sylius_twig_hooks:
             paypal:
                 template: '@SyliusPayPalPlugin/shop/checkout/select_payment/content/form/select_payment/payment/choice/details/paypal.html.twig'
                 priority: -100
+            paypal_messaging:
+                template: '@SyliusPayPalPlugin/shop/checkout/select_payment/content/form/select_payment/payment/choice/details/paypal_messaging.html.twig'
+                priority: -200

--- a/config/app/twig_hooks/shop/product/show.yaml
+++ b/config/app/twig_hooks/shop/product/show.yaml
@@ -4,3 +4,6 @@ sylius_twig_hooks:
             paypal_checkout:
                 template: '@SyliusPayPalPlugin/shop/product/show/content/info/summary/paypal_checkout.html.twig'
                 priority: 50
+            paypal_messaging:
+                template: '@SyliusPayPalPlugin/shop/product/show/content/info/summary/paypal_messaging.html.twig'
+                priority: 40

--- a/config/services.xml
+++ b/config/services.xml
@@ -305,6 +305,8 @@
             <argument type="service" id="sylius_paypal.provider.paypal_configuration" />
             <argument type="service" id="Sylius\PayPalPlugin\Provider\PayPalFundingSourcesConfigurationProviderInterface" />
             <argument>%sylius_paypal.web_url%</argument>
+            <argument>%sylius_paypal.sandbox%</argument>
+            <argument>%sylius_paypal.test_buyer_country%</argument>
         </service>
         <service id="Sylius\PayPalPlugin\Provider\PayPalWebSdkConfigurationProviderInterface" alias="sylius_paypal.provider.paypal_web_sdk_configuration" />
 

--- a/config/services.xml
+++ b/config/services.xml
@@ -296,6 +296,7 @@
             <argument type="service" id="sylius.repository.payment_method" />
         </service>
         <service id="Sylius\PayPalPlugin\Provider\PayPalConfigurationProviderInterface" alias="sylius_paypal.provider.paypal_configuration" />
+        <service id="Sylius\PayPalPlugin\Provider\PayPalFundingSourcesConfigurationProviderInterface" alias="sylius_paypal.provider.paypal_configuration" />
 
         <service
             id="sylius_paypal.provider.paypal_web_sdk_configuration"
@@ -388,6 +389,8 @@
 
         <service id="sylius_paypal.twig.extension.paypal" class="Sylius\PayPalPlugin\Twig\PayPalExtension">
             <argument>%sylius_paypal.sandbox%</argument>
+            <argument type="service" id="Sylius\PayPalPlugin\Provider\PayPalFundingSourcesConfigurationProviderInterface" />
+            <argument type="service" id="sylius.context.channel" />
             <tag name="twig.extension" />
         </service>
 

--- a/config/services.xml
+++ b/config/services.xml
@@ -303,6 +303,7 @@
             class="Sylius\PayPalPlugin\Provider\PayPalWebSdkConfigurationProvider"
         >
             <argument type="service" id="sylius_paypal.provider.paypal_configuration" />
+            <argument type="service" id="Sylius\PayPalPlugin\Provider\PayPalFundingSourcesConfigurationProviderInterface" />
             <argument>%sylius_paypal.web_url%</argument>
         </service>
         <service id="Sylius\PayPalPlugin\Provider\PayPalWebSdkConfigurationProviderInterface" alias="sylius_paypal.provider.paypal_web_sdk_configuration" />

--- a/config/services/controller.xml
+++ b/config/services/controller.xml
@@ -109,6 +109,7 @@
             <argument type="service" id="sylius_paypal.provider.available_countries" />
             <argument type="service" id="sylius_paypal.processor.locale" />
             <argument type="service" id="sylius_paypal.provider.paypal_web_sdk_configuration" />
+            <argument type="service" id="Sylius\PayPalPlugin\Provider\PayPalFundingSourcesConfigurationProviderInterface" />
         </service>
 
         <service id="sylius_paypal.controller.pay_with_paypal_form" class="Sylius\PayPalPlugin\Controller\PayWithPayPalFormAction">

--- a/src/Controller/PayPalButtonsController.php
+++ b/src/Controller/PayPalButtonsController.php
@@ -80,6 +80,7 @@ final readonly class PayPalButtonsController
                 'webSdkScriptUrl' => $this->getWebSdkConfigurationProvider()->getScriptUrl(),
                 'webSdkInstanceConfig' => $this->getWebSdkConfigurationProvider()->getInstanceConfig($channel, 'product-details'),
                 'paylaterEnabled' => $this->getFundingSourcesConfigurationProvider()->isPayLaterEnabled($channel),
+                'venmoEnabled' => $this->getFundingSourcesConfigurationProvider()->isVenmoEnabled($channel),
             ]));
         } catch (\InvalidArgumentException $exception) {
             return new Response('');
@@ -108,6 +109,7 @@ final readonly class PayPalButtonsController
                 'webSdkScriptUrl' => $this->getWebSdkConfigurationProvider()->getScriptUrl(),
                 'webSdkInstanceConfig' => $this->getWebSdkConfigurationProvider()->getInstanceConfig($channel, 'cart'),
                 'paylaterEnabled' => $this->getFundingSourcesConfigurationProvider()->isPayLaterEnabled($channel),
+                'venmoEnabled' => $this->getFundingSourcesConfigurationProvider()->isVenmoEnabled($channel),
             ]));
         } catch (\InvalidArgumentException $exception) {
             return new Response('');
@@ -137,6 +139,7 @@ final readonly class PayPalButtonsController
                 'webSdkScriptUrl' => $this->getWebSdkConfigurationProvider()->getScriptUrl(),
                 'webSdkInstanceConfig' => $this->getWebSdkConfigurationProvider()->getInstanceConfig($channel, 'checkout'),
                 'paylaterEnabled' => $this->getFundingSourcesConfigurationProvider()->isPayLaterEnabled($channel),
+                'venmoEnabled' => $this->getFundingSourcesConfigurationProvider()->isVenmoEnabled($channel),
             ]));
         } catch (\InvalidArgumentException $exception) {
             return new Response('');

--- a/src/Controller/PayPalButtonsController.php
+++ b/src/Controller/PayPalButtonsController.php
@@ -98,6 +98,7 @@ final readonly class PayPalButtonsController
         try {
             return new Response($this->twig->render('@SyliusPayPalPlugin/pay_from_cart_page.html.twig', [
                 'available_countries' => $this->availableCountriesProvider->provide(),
+                'amount' => number_format($order->getTotal() / 100, 2, '.', ''),
                 'clientId' => $this->payPalConfigurationProvider->getClientId($channel),
                 'createPayPalOrderFromCartUrl' => $this->router->generate('sylius_paypal_shop_create_paypal_order_from_cart', ['id' => $orderId]),
                 'currency' => $order->getCurrencyCode(),
@@ -127,6 +128,7 @@ final readonly class PayPalButtonsController
         try {
             return new Response($this->twig->render('@SyliusPayPalPlugin/pay_from_payment_page.html.twig', [
                 'available_countries' => $this->availableCountriesProvider->provide(),
+                'amount' => number_format($order->getTotal() / 100, 2, '.', ''),
                 'cancelPayPalPaymentUrl' => $this->router->generate('sylius_paypal_shop_cancel_payment'),
                 'clientId' => $this->payPalConfigurationProvider->getClientId($channel),
                 'currency' => $order->getCurrencyCode(),

--- a/src/Controller/PayPalButtonsController.php
+++ b/src/Controller/PayPalButtonsController.php
@@ -21,6 +21,7 @@ use Sylius\Component\Locale\Context\LocaleContextInterface;
 use Sylius\PayPalPlugin\Processor\LocaleProcessorInterface;
 use Sylius\PayPalPlugin\Provider\AvailableCountriesProviderInterface;
 use Sylius\PayPalPlugin\Provider\PayPalConfigurationProviderInterface;
+use Sylius\PayPalPlugin\Provider\PayPalFundingSourcesConfigurationProviderInterface;
 use Sylius\PayPalPlugin\Provider\PayPalWebSdkConfigurationProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -40,7 +41,17 @@ final readonly class PayPalButtonsController
         private AvailableCountriesProviderInterface $availableCountriesProvider,
         private LocaleProcessorInterface $localeProcessor,
         private ?PayPalWebSdkConfigurationProviderInterface $webSdkConfigurationProvider = null,
+        private ?PayPalFundingSourcesConfigurationProviderInterface $fundingSourcesConfigurationProvider = null,
     ) {
+        if (null === $this->fundingSourcesConfigurationProvider) {
+            trigger_deprecation(
+                'sylius/paypal-plugin',
+                '2.1',
+                'Not passing an instance of %s to %s constructor is deprecated and will be required in 3.0.',
+                PayPalFundingSourcesConfigurationProviderInterface::class,
+                self::class,
+            );
+        }
         if (null === $this->webSdkConfigurationProvider) {
             trigger_deprecation(
                 'sylius/paypal-plugin',
@@ -68,6 +79,7 @@ final readonly class PayPalButtonsController
                 'processPayPalOrderUrl' => $this->router->generate('sylius_paypal_shop_process_paypal_order'),
                 'webSdkScriptUrl' => $this->getWebSdkConfigurationProvider()->getScriptUrl(),
                 'webSdkInstanceConfig' => $this->getWebSdkConfigurationProvider()->getInstanceConfig($channel, 'product-details'),
+                'paylaterEnabled' => $this->getFundingSourcesConfigurationProvider()->isPayLaterEnabled($channel),
             ]));
         } catch (\InvalidArgumentException $exception) {
             return new Response('');
@@ -95,6 +107,7 @@ final readonly class PayPalButtonsController
                 'processPayPalOrderUrl' => $this->router->generate('sylius_paypal_shop_process_paypal_order'),
                 'webSdkScriptUrl' => $this->getWebSdkConfigurationProvider()->getScriptUrl(),
                 'webSdkInstanceConfig' => $this->getWebSdkConfigurationProvider()->getInstanceConfig($channel, 'cart'),
+                'paylaterEnabled' => $this->getFundingSourcesConfigurationProvider()->isPayLaterEnabled($channel),
             ]));
         } catch (\InvalidArgumentException $exception) {
             return new Response('');
@@ -123,6 +136,7 @@ final readonly class PayPalButtonsController
                 'partnerAttributionId' => $this->payPalConfigurationProvider->getPartnerAttributionId($channel),
                 'webSdkScriptUrl' => $this->getWebSdkConfigurationProvider()->getScriptUrl(),
                 'webSdkInstanceConfig' => $this->getWebSdkConfigurationProvider()->getInstanceConfig($channel, 'checkout'),
+                'paylaterEnabled' => $this->getFundingSourcesConfigurationProvider()->isPayLaterEnabled($channel),
             ]));
         } catch (\InvalidArgumentException $exception) {
             return new Response('');
@@ -139,5 +153,17 @@ final readonly class PayPalButtonsController
         }
 
         return $this->webSdkConfigurationProvider;
+    }
+
+    private function getFundingSourcesConfigurationProvider(): PayPalFundingSourcesConfigurationProviderInterface
+    {
+        if (null === $this->fundingSourcesConfigurationProvider) {
+            throw new \RuntimeException(sprintf(
+                'An instance of "%s" is required to render the v6 Web SDK placements.',
+                PayPalFundingSourcesConfigurationProviderInterface::class,
+            ));
+        }
+
+        return $this->fundingSourcesConfigurationProvider;
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -34,6 +34,7 @@ final class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->booleanNode('sandbox')->defaultTrue()->end()
+                ->scalarNode('test_buyer_country')->defaultNull()->end()
                 ->arrayNode('logging')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/src/DependencyInjection/SyliusPayPalExtension.php
+++ b/src/DependencyInjection/SyliusPayPalExtension.php
@@ -91,6 +91,7 @@ final class SyliusPayPalExtension extends Extension implements PrependExtensionI
     {
         $container->setParameter('sylius_paypal.logging.increased', (bool) $config['logging']['increased']);
         $container->setParameter('sylius_paypal.sandbox', (bool) $config['sandbox']);
+        $container->setParameter('sylius_paypal.test_buyer_country', $config['test_buyer_country']);
         $container->setParameter('sylius_paypal.prioritized_factory_name', self::PAYPAL_FACTORY_NAME);
 
         if ($container->getParameter('sylius_paypal.sandbox')) {
@@ -113,6 +114,11 @@ final class SyliusPayPalExtension extends Extension implements PrependExtensionI
         $sandboxEnv = $_ENV['SYLIUS_PAYPAL_SANDBOX_ENABLED'] ?? null;
         if ($sandboxEnv !== null) {
             $envConfig['sandbox'] = filter_var($sandboxEnv, \FILTER_VALIDATE_BOOLEAN, \FILTER_NULL_ON_FAILURE) ?? false;
+        }
+
+        $testBuyerCountryEnv = $_ENV['SYLIUS_PAYPAL_TEST_BUYER_COUNTRY'] ?? null;
+        if ($testBuyerCountryEnv !== null) {
+            $envConfig['test_buyer_country'] = $testBuyerCountryEnv;
         }
 
         $loggingEnv = $_ENV['SYLIUS_PAYPAL_LOGGING_INCREASED'] ?? null;

--- a/src/Form/Type/PayPalConfigurationType.php
+++ b/src/Form/Type/PayPalConfigurationType.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\PayPalPlugin\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -43,12 +44,27 @@ final class PayPalConfigurationType extends AbstractType
             ->add('use_authorize', HiddenType::class, ['data' => true, 'attr' => ['readonly' => true]])
             ->add('reports_sftp_username', TextType::class, ['label' => 'sylius_paypal.sftp_username', 'required' => false])
             ->add('reports_sftp_password', TextType::class, ['label' => 'sylius_paypal.sftp_password', 'required' => false])
+            // Eligibility (from PayPal's own API) remains the primary gate for all three - these are
+            // merchant opt-outs, not opt-ins, so they default to checked/true for both new and existing
+            // (pre-2.1.0) payment methods, whose stored config simply won't have these keys yet.
+            //
+            // The default is applied via PRE_SET_DATA below (backfilling the missing key), not via a
+            // 'data' option here: 'data' locks the field's value (Symfony's $dataLocked), which would
+            // make the checkbox permanently ignore whatever is actually stored and always render as
+            // checked, so unchecking it would never visibly persist.
+            ->add('paylater_enabled', CheckboxType::class, ['label' => 'sylius_paypal.paylater_enabled', 'required' => false])
+            ->add('venmo_enabled', CheckboxType::class, ['label' => 'sylius_paypal.venmo_enabled', 'required' => false])
+            ->add('messaging_enabled', CheckboxType::class, ['label' => 'sylius_paypal.messaging_enabled', 'required' => false])
         ;
 
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use (&$originalData): void {
             $data = $event->getData();
             if (is_array($data)) {
                 $originalData = $data;
+                $data['paylater_enabled'] ??= true;
+                $data['venmo_enabled'] ??= true;
+                $data['messaging_enabled'] ??= true;
+                $event->setData($data);
             }
         });
 

--- a/src/Provider/PayPalConfigurationProvider.php
+++ b/src/Provider/PayPalConfigurationProvider.php
@@ -20,7 +20,7 @@ use Sylius\Component\Core\Repository\PaymentMethodRepositoryInterface;
 use Sylius\PayPalPlugin\DependencyInjection\SyliusPayPalExtension;
 use Webmozart\Assert\Assert;
 
-final readonly class PayPalConfigurationProvider implements PayPalConfigurationProviderInterface
+final readonly class PayPalConfigurationProvider implements PayPalConfigurationProviderInterface, PayPalFundingSourcesConfigurationProviderInterface
 {
     /** @param PaymentMethodRepositoryInterface<PaymentMethodInterface> $paymentMethodRepository */
     public function __construct(private PaymentMethodRepositoryInterface $paymentMethodRepository)
@@ -41,6 +41,21 @@ final readonly class PayPalConfigurationProvider implements PayPalConfigurationP
         Assert::keyExists($config, 'partner_attribution_id');
 
         return (string) $config['partner_attribution_id'];
+    }
+
+    public function isPayLaterEnabled(ChannelInterface $channel): bool
+    {
+        return (bool) ($this->getPayPalPaymentMethodConfig($channel)['paylater_enabled'] ?? true);
+    }
+
+    public function isVenmoEnabled(ChannelInterface $channel): bool
+    {
+        return (bool) ($this->getPayPalPaymentMethodConfig($channel)['venmo_enabled'] ?? true);
+    }
+
+    public function isMessagingEnabled(ChannelInterface $channel): bool
+    {
+        return (bool) ($this->getPayPalPaymentMethodConfig($channel)['messaging_enabled'] ?? true);
     }
 
     private function getPayPalPaymentMethodConfig(ChannelInterface $channel): array

--- a/src/Provider/PayPalFundingSourcesConfigurationProviderInterface.php
+++ b/src/Provider/PayPalFundingSourcesConfigurationProviderInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\PayPalPlugin\Provider;
+
+use Sylius\Component\Core\Model\ChannelInterface;
+
+interface PayPalFundingSourcesConfigurationProviderInterface
+{
+    public function isPayLaterEnabled(ChannelInterface $channel): bool;
+
+    public function isVenmoEnabled(ChannelInterface $channel): bool;
+
+    public function isMessagingEnabled(ChannelInterface $channel): bool;
+}

--- a/src/Provider/PayPalWebSdkConfigurationProvider.php
+++ b/src/Provider/PayPalWebSdkConfigurationProvider.php
@@ -21,6 +21,8 @@ final readonly class PayPalWebSdkConfigurationProvider implements PayPalWebSdkCo
         private PayPalConfigurationProviderInterface $payPalConfigurationProvider,
         private PayPalFundingSourcesConfigurationProviderInterface $fundingSourcesConfigurationProvider,
         private string $webUrl,
+        private bool $sandbox,
+        private ?string $testBuyerCountry,
     ) {
     }
 
@@ -36,11 +38,19 @@ final readonly class PayPalWebSdkConfigurationProvider implements PayPalWebSdkCo
             $components[] = 'venmo-payments';
         }
 
-        return [
+        $config = [
             'clientId' => $this->payPalConfigurationProvider->getClientId($channel),
             'components' => $components,
             'pageType' => $pageType,
             'partnerAttributionId' => $this->payPalConfigurationProvider->getPartnerAttributionId($channel),
         ];
+
+        // Only ever simulate a buyer location in sandbox - PayPal support: this must never be sent in
+        // production, so the sandbox flag is a hard gate, not just a default.
+        if ($this->sandbox && $this->testBuyerCountry !== null) {
+            $config['testBuyerCountry'] = $this->testBuyerCountry;
+        }
+
+        return $config;
     }
 }

--- a/src/Provider/PayPalWebSdkConfigurationProvider.php
+++ b/src/Provider/PayPalWebSdkConfigurationProvider.php
@@ -19,6 +19,7 @@ final readonly class PayPalWebSdkConfigurationProvider implements PayPalWebSdkCo
 {
     public function __construct(
         private PayPalConfigurationProviderInterface $payPalConfigurationProvider,
+        private PayPalFundingSourcesConfigurationProviderInterface $fundingSourcesConfigurationProvider,
         private string $webUrl,
     ) {
     }
@@ -30,9 +31,14 @@ final readonly class PayPalWebSdkConfigurationProvider implements PayPalWebSdkCo
 
     public function getInstanceConfig(ChannelInterface $channel, string $pageType): array
     {
+        $components = ['paypal-payments'];
+        if ($this->fundingSourcesConfigurationProvider->isVenmoEnabled($channel)) {
+            $components[] = 'venmo-payments';
+        }
+
         return [
             'clientId' => $this->payPalConfigurationProvider->getClientId($channel),
-            'components' => ['paypal-payments'],
+            'components' => $components,
             'pageType' => $pageType,
             'partnerAttributionId' => $this->payPalConfigurationProvider->getPartnerAttributionId($channel),
         ];

--- a/src/Twig/PayPalExtension.php
+++ b/src/Twig/PayPalExtension.php
@@ -14,15 +14,21 @@ declare(strict_types=1);
 namespace Sylius\PayPalPlugin\Twig;
 
 use Payum\Core\Model\GatewayConfigInterface;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\PayPalPlugin\DependencyInjection\SyliusPayPalExtension;
+use Sylius\PayPalPlugin\Provider\PayPalFundingSourcesConfigurationProviderInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
 final class PayPalExtension extends AbstractExtension
 {
-    public function __construct(private readonly bool $sandbox)
-    {
+    public function __construct(
+        private readonly bool $sandbox,
+        private readonly PayPalFundingSourcesConfigurationProviderInterface $fundingSourcesConfigurationProvider,
+        private readonly ChannelContextInterface $channelContext,
+    ) {
     }
 
     public function getFunctions(): array
@@ -30,12 +36,26 @@ final class PayPalExtension extends AbstractExtension
         return [
             new TwigFunction('sylius_is_paypal_enabled', [$this, 'isPayPalEnabled']),
             new TwigFunction('sylius_is_paypal_sandbox', [$this, 'isSandbox']),
+            new TwigFunction('sylius_paypal_is_messaging_enabled', [$this, 'isMessagingEnabled']),
         ];
     }
 
     public function isSandbox(): bool
     {
         return $this->sandbox;
+    }
+
+    public function isMessagingEnabled(): bool
+    {
+        try {
+            /** @var ChannelInterface $channel */
+            $channel = $this->channelContext->getChannel();
+
+            return $this->fundingSourcesConfigurationProvider->isMessagingEnabled($channel);
+        } catch (\InvalidArgumentException) {
+            // No PayPal payment method configured for this channel yet.
+            return false;
+        }
     }
 
     public function isPayPalEnabled(iterable $paymentMethods): bool

--- a/templates/admin/payment_method/form/section/gateway_configuration/messaging_enabled.html.twig
+++ b/templates/admin/payment_method/form/section/gateway_configuration/messaging_enabled.html.twig
@@ -1,0 +1,5 @@
+{% set form = hookable_metadata.context.form.gatewayConfig.config %}
+
+<div class="col-12 col-md-6">
+    {{ form_row(form.messaging_enabled, sylius_test_form_attribute('messaging-enabled')) }}
+</div>

--- a/templates/admin/payment_method/form/section/gateway_configuration/paylater_enabled.html.twig
+++ b/templates/admin/payment_method/form/section/gateway_configuration/paylater_enabled.html.twig
@@ -1,0 +1,5 @@
+{% set form = hookable_metadata.context.form.gatewayConfig.config %}
+
+<div class="col-12 col-md-6">
+    {{ form_row(form.paylater_enabled, sylius_test_form_attribute('paylater-enabled')) }}
+</div>

--- a/templates/admin/payment_method/form/section/gateway_configuration/venmo_enabled.html.twig
+++ b/templates/admin/payment_method/form/section/gateway_configuration/venmo_enabled.html.twig
@@ -1,0 +1,5 @@
+{% set form = hookable_metadata.context.form.gatewayConfig.config %}
+
+<div class="col-12 col-md-6">
+    {{ form_row(form.venmo_enabled, sylius_test_form_attribute('venmo-enabled')) }}
+</div>

--- a/templates/pay_from_cart_page.html.twig
+++ b/templates/pay_from_cart_page.html.twig
@@ -3,6 +3,7 @@
         scriptUrl: webSdkScriptUrl,
         instanceConfig: webSdkInstanceConfig,
         currencyCode: currency,
+        amount: amount,
         createOrderUrl: createPayPalOrderFromCartUrl,
         captureOrderUrl: processPayPalOrderUrl,
         cancelOrderUrl: path('sylius_paypal_shop_cancel_order'),

--- a/templates/pay_from_cart_page.html.twig
+++ b/templates/pay_from_cart_page.html.twig
@@ -8,8 +8,10 @@
         cancelOrderUrl: path('sylius_paypal_shop_cancel_order'),
         errorUrl: errorPayPalPaymentUrl,
         loadingSelector: '[data-live-name-value="sylius_shop:cart:form"] [data-loading]',
+        payLaterEnabled: paylaterEnabled,
     }) }}
     style="margin-top: 10px"
 >
     <paypal-button {{ stimulus_target('@sylius/paypal-plugin/paypal-web-sdk', 'paypalButton') }} type="pay" class="paypal-gold" hidden></paypal-button>
+    <paypal-pay-later-button {{ stimulus_target('@sylius/paypal-plugin/paypal-web-sdk', 'payLaterButton') }} hidden></paypal-pay-later-button>
 </div>

--- a/templates/pay_from_cart_page.html.twig
+++ b/templates/pay_from_cart_page.html.twig
@@ -9,9 +9,11 @@
         errorUrl: errorPayPalPaymentUrl,
         loadingSelector: '[data-live-name-value="sylius_shop:cart:form"] [data-loading]',
         payLaterEnabled: paylaterEnabled,
+        venmoEnabled: venmoEnabled,
     }) }}
     style="margin-top: 10px"
 >
     <paypal-button {{ stimulus_target('@sylius/paypal-plugin/paypal-web-sdk', 'paypalButton') }} type="pay" class="paypal-gold" hidden></paypal-button>
     <paypal-pay-later-button {{ stimulus_target('@sylius/paypal-plugin/paypal-web-sdk', 'payLaterButton') }} hidden></paypal-pay-later-button>
+    <venmo-button {{ stimulus_target('@sylius/paypal-plugin/paypal-web-sdk', 'venmoButton') }} hidden></venmo-button>
 </div>

--- a/templates/pay_from_payment_page.html.twig
+++ b/templates/pay_from_payment_page.html.twig
@@ -8,9 +8,11 @@
         cancelOrderUrl: cancelPayPalPaymentUrl,
         errorUrl: errorPayPalPaymentUrl,
         payLaterEnabled: paylaterEnabled,
+        venmoEnabled: venmoEnabled,
     }) }}
     style="width:250px"
 >
     <paypal-button {{ stimulus_target('@sylius/paypal-plugin/paypal-web-sdk', 'paypalButton') }} type="pay" class="paypal-gold" hidden></paypal-button>
     <paypal-pay-later-button {{ stimulus_target('@sylius/paypal-plugin/paypal-web-sdk', 'payLaterButton') }} hidden></paypal-pay-later-button>
+    <venmo-button {{ stimulus_target('@sylius/paypal-plugin/paypal-web-sdk', 'venmoButton') }} hidden></venmo-button>
 </div>

--- a/templates/pay_from_payment_page.html.twig
+++ b/templates/pay_from_payment_page.html.twig
@@ -7,8 +7,10 @@
         captureOrderUrl: completePayPalOrderFromPaymentPageUrl,
         cancelOrderUrl: cancelPayPalPaymentUrl,
         errorUrl: errorPayPalPaymentUrl,
+        payLaterEnabled: paylaterEnabled,
     }) }}
     style="width:250px"
 >
     <paypal-button {{ stimulus_target('@sylius/paypal-plugin/paypal-web-sdk', 'paypalButton') }} type="pay" class="paypal-gold" hidden></paypal-button>
+    <paypal-pay-later-button {{ stimulus_target('@sylius/paypal-plugin/paypal-web-sdk', 'payLaterButton') }} hidden></paypal-pay-later-button>
 </div>

--- a/templates/pay_from_payment_page.html.twig
+++ b/templates/pay_from_payment_page.html.twig
@@ -3,6 +3,7 @@
         scriptUrl: webSdkScriptUrl,
         instanceConfig: webSdkInstanceConfig,
         currencyCode: currency,
+        amount: amount,
         createOrderUrl: createPayPalOrderFromPaymentPageUrl,
         captureOrderUrl: completePayPalOrderFromPaymentPageUrl,
         cancelOrderUrl: cancelPayPalPaymentUrl,

--- a/templates/pay_from_product_page.html.twig
+++ b/templates/pay_from_product_page.html.twig
@@ -10,8 +10,10 @@
         errorUrl: errorPayPalPaymentUrl,
         loadingSelector: '[data-live-name-value="sylius_shop:product:add_to_cart_form"] [data-loading]',
         payLaterEnabled: paylaterEnabled,
+        venmoEnabled: venmoEnabled,
     }) }}
 >
     <paypal-button {{ stimulus_target('@sylius/paypal-plugin/paypal-web-sdk', 'paypalButton') }} type="pay" class="paypal-gold" hidden></paypal-button>
     <paypal-pay-later-button {{ stimulus_target('@sylius/paypal-plugin/paypal-web-sdk', 'payLaterButton') }} hidden></paypal-pay-later-button>
+    <venmo-button {{ stimulus_target('@sylius/paypal-plugin/paypal-web-sdk', 'venmoButton') }} hidden></venmo-button>
 </div>

--- a/templates/pay_from_product_page.html.twig
+++ b/templates/pay_from_product_page.html.twig
@@ -9,7 +9,9 @@
         cancelOrderUrl: path('sylius_paypal_shop_cancel_order'),
         errorUrl: errorPayPalPaymentUrl,
         loadingSelector: '[data-live-name-value="sylius_shop:product:add_to_cart_form"] [data-loading]',
+        payLaterEnabled: paylaterEnabled,
     }) }}
 >
     <paypal-button {{ stimulus_target('@sylius/paypal-plugin/paypal-web-sdk', 'paypalButton') }} type="pay" class="paypal-gold" hidden></paypal-button>
+    <paypal-pay-later-button {{ stimulus_target('@sylius/paypal-plugin/paypal-web-sdk', 'payLaterButton') }} hidden></paypal-pay-later-button>
 </div>

--- a/templates/shop/cart/index/content/form/sections/general/paypal_messaging.html.twig
+++ b/templates/shop/cart/index/content/form/sections/general/paypal_messaging.html.twig
@@ -1,0 +1,16 @@
+{% if sylius_paypal_is_messaging_enabled() %}
+    {#
+        TODO (SDD §6.1): the Pay Later messaging spec PayPal gave us for this integration is a
+        dead link (it points at PayPal's sandbox card-testing page, not real messaging
+        documentation). Direct inspection of the shipped web-sdk/v6/core bundle confirms
+        "paypal-messages" only exists as a components enum string
+        (PAYPAL_MESSAGES: "paypal-messages") - there is no
+        customElements.define("paypal-messages", ...) anywhere in that bundle, so the real
+        custom element isn't implemented in this core chunk and its attribute API can't be
+        verified. This slot is scaffolding only - swap in the real
+        `paypal.Message()`/`<paypal-messages>` web component call, its placement/threshold
+        rules, and its exact configuration API once PayPal provides a working spec. Do not
+        invent behavior here.
+    #}
+    <div data-paypal-messaging-placeholder></div>
+{% endif %}

--- a/templates/shop/checkout/select_payment/content/form/select_payment/payment/choice/details/paypal_messaging.html.twig
+++ b/templates/shop/checkout/select_payment/content/form/select_payment/payment/choice/details/paypal_messaging.html.twig
@@ -1,0 +1,10 @@
+{% if
+    hookable_metadata.context.method.gatewayConfig.factoryName|default('') == constant('Sylius\\PayPalPlugin\\DependencyInjection\\SyliusPayPalExtension::PAYPAL_FACTORY_NAME') and
+    sylius_paypal_is_messaging_enabled()
+%}
+    {#
+        TODO (SDD §6.1): see paypal_messaging.html.twig under cart/index for the full note.
+        This slot is scaffolding only, pending a working messaging spec from PayPal.
+    #}
+    <div data-paypal-messaging-placeholder></div>
+{% endif %}

--- a/templates/shop/product/show/content/info/summary/paypal_messaging.html.twig
+++ b/templates/shop/product/show/content/info/summary/paypal_messaging.html.twig
@@ -1,0 +1,7 @@
+{% if sylius_paypal_is_messaging_enabled() %}
+    {#
+        TODO (SDD §6.1): see paypal_messaging.html.twig under cart/index for the full note.
+        This slot is scaffolding only, pending a working messaging spec from PayPal.
+    #}
+    <div data-paypal-messaging-placeholder></div>
+{% endif %}

--- a/tests/Unit/Controller/PayPalButtonsControllerTest.php
+++ b/tests/Unit/Controller/PayPalButtonsControllerTest.php
@@ -1,0 +1,173 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\PayPalPlugin\Unit\Controller;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Locale\Context\LocaleContextInterface;
+use Sylius\PayPalPlugin\Controller\PayPalButtonsController;
+use Sylius\PayPalPlugin\Processor\LocaleProcessorInterface;
+use Sylius\PayPalPlugin\Provider\AvailableCountriesProviderInterface;
+use Sylius\PayPalPlugin\Provider\PayPalConfigurationProviderInterface;
+use Sylius\PayPalPlugin\Provider\PayPalFundingSourcesConfigurationProviderInterface;
+use Sylius\PayPalPlugin\Provider\PayPalWebSdkConfigurationProviderInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Twig\Environment;
+
+final class PayPalButtonsControllerTest extends TestCase
+{
+    private Environment&MockObject $twig;
+
+    private UrlGeneratorInterface&MockObject $router;
+
+    private ChannelContextInterface&MockObject $channelContext;
+
+    private LocaleContextInterface&MockObject $localeContext;
+
+    private PayPalConfigurationProviderInterface&MockObject $payPalConfigurationProvider;
+
+    /** @var OrderRepositoryInterface<OrderInterface>&MockObject */
+    private OrderRepositoryInterface&MockObject $orderRepository;
+
+    private AvailableCountriesProviderInterface&MockObject $availableCountriesProvider;
+
+    private LocaleProcessorInterface&MockObject $localeProcessor;
+
+    private PayPalWebSdkConfigurationProviderInterface&MockObject $webSdkConfigurationProvider;
+
+    private PayPalFundingSourcesConfigurationProviderInterface&MockObject $fundingSourcesConfigurationProvider;
+
+    private ChannelInterface&MockObject $channel;
+
+    private PayPalButtonsController $controller;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->twig = $this->createMock(Environment::class);
+        $this->router = $this->createMock(UrlGeneratorInterface::class);
+        $this->channelContext = $this->createMock(ChannelContextInterface::class);
+        $this->localeContext = $this->createMock(LocaleContextInterface::class);
+        $this->payPalConfigurationProvider = $this->createMock(PayPalConfigurationProviderInterface::class);
+        $this->orderRepository = $this->createMock(OrderRepositoryInterface::class);
+        $this->availableCountriesProvider = $this->createMock(AvailableCountriesProviderInterface::class);
+        $this->localeProcessor = $this->createMock(LocaleProcessorInterface::class);
+        $this->webSdkConfigurationProvider = $this->createMock(PayPalWebSdkConfigurationProviderInterface::class);
+        $this->fundingSourcesConfigurationProvider = $this->createMock(PayPalFundingSourcesConfigurationProviderInterface::class);
+
+        $this->channel = $this->createMock(ChannelInterface::class);
+        $this->channelContext->method('getChannel')->willReturn($this->channel);
+        $this->localeContext->method('getLocaleCode')->willReturn('en_US');
+        $this->localeProcessor->method('process')->willReturnArgument(0);
+        $this->availableCountriesProvider->method('provide')->willReturn([]);
+        $this->router->method('generate')->willReturn('/some-url');
+        $this->webSdkConfigurationProvider->method('getScriptUrl')->willReturn('https://www.paypal.com/web-sdk/v6/core');
+        $this->webSdkConfigurationProvider->method('getInstanceConfig')->willReturn(['clientId' => 'CLIENT_ID']);
+
+        $this->controller = new PayPalButtonsController(
+            $this->twig,
+            $this->router,
+            $this->channelContext,
+            $this->localeContext,
+            $this->payPalConfigurationProvider,
+            $this->orderRepository,
+            $this->availableCountriesProvider,
+            $this->localeProcessor,
+            $this->webSdkConfigurationProvider,
+            $this->fundingSourcesConfigurationProvider,
+        );
+    }
+
+    #[Test]
+    public function it_passes_paylater_enabled_to_the_product_page_template(): void
+    {
+        $this->fundingSourcesConfigurationProvider->method('isPayLaterEnabled')->with($this->channel)->willReturn(true);
+
+        $capturedContext = null;
+        $this->twig->method('render')
+            ->with('@SyliusPayPalPlugin/pay_from_product_page.html.twig', self::isType('array'))
+            ->willReturnCallback(function (string $template, array $context) use (&$capturedContext): string {
+                $capturedContext = $context;
+
+                return '';
+            });
+
+        $this->controller->renderProductPageButtonsAction(Request::create('/'));
+
+        self::assertTrue($capturedContext['paylaterEnabled']);
+    }
+
+    #[Test]
+    public function it_passes_paylater_enabled_to_the_cart_page_template(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getCurrencyCode')->willReturn('USD');
+        $this->orderRepository->method('find')->willReturn($order);
+        $this->fundingSourcesConfigurationProvider->method('isPayLaterEnabled')->with($this->channel)->willReturn(false);
+
+        $capturedContext = null;
+        $this->twig->method('render')
+            ->with('@SyliusPayPalPlugin/pay_from_cart_page.html.twig', self::isType('array'))
+            ->willReturnCallback(function (string $template, array $context) use (&$capturedContext): string {
+                $capturedContext = $context;
+
+                return '';
+            });
+
+        $this->controller->renderCartPageButtonsAction(Request::create('/', 'GET', ['orderId' => 1]));
+
+        self::assertFalse($capturedContext['paylaterEnabled']);
+    }
+
+    #[Test]
+    public function it_passes_paylater_enabled_to_the_payment_page_template(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getCurrencyCode')->willReturn('USD');
+        $this->orderRepository->method('find')->willReturn($order);
+        $this->fundingSourcesConfigurationProvider->method('isPayLaterEnabled')->with($this->channel)->willReturn(true);
+
+        $capturedContext = null;
+        $this->twig->method('render')
+            ->with('@SyliusPayPalPlugin/pay_from_payment_page.html.twig', self::isType('array'))
+            ->willReturnCallback(function (string $template, array $context) use (&$capturedContext): string {
+                $capturedContext = $context;
+
+                return '';
+            });
+
+        $this->controller->renderPaymentPageButtonsAction(Request::create('/', 'GET', ['orderId' => 1]));
+
+        self::assertTrue($capturedContext['paylaterEnabled']);
+    }
+
+    #[Test]
+    public function it_returns_an_empty_response_when_no_pay_pal_payment_method_is_configured(): void
+    {
+        $this->payPalConfigurationProvider
+            ->method('getClientId')
+            ->willThrowException(new \InvalidArgumentException('No PayPal payment method defined'));
+
+        $response = $this->controller->renderProductPageButtonsAction(Request::create('/'));
+
+        self::assertSame('', $response->getContent());
+    }
+}

--- a/tests/Unit/Controller/PayPalButtonsControllerTest.php
+++ b/tests/Unit/Controller/PayPalButtonsControllerTest.php
@@ -100,6 +100,7 @@ final class PayPalButtonsControllerTest extends TestCase
     public function it_passes_paylater_enabled_to_the_product_page_template(): void
     {
         $this->fundingSourcesConfigurationProvider->method('isPayLaterEnabled')->with($this->channel)->willReturn(true);
+        $this->fundingSourcesConfigurationProvider->method('isVenmoEnabled')->with($this->channel)->willReturn(false);
 
         $capturedContext = null;
         $this->twig->method('render')
@@ -113,6 +114,7 @@ final class PayPalButtonsControllerTest extends TestCase
         $this->controller->renderProductPageButtonsAction(Request::create('/'));
 
         self::assertTrue($capturedContext['paylaterEnabled']);
+        self::assertFalse($capturedContext['venmoEnabled']);
     }
 
     #[Test]
@@ -122,6 +124,7 @@ final class PayPalButtonsControllerTest extends TestCase
         $order->method('getCurrencyCode')->willReturn('USD');
         $this->orderRepository->method('find')->willReturn($order);
         $this->fundingSourcesConfigurationProvider->method('isPayLaterEnabled')->with($this->channel)->willReturn(false);
+        $this->fundingSourcesConfigurationProvider->method('isVenmoEnabled')->with($this->channel)->willReturn(true);
 
         $capturedContext = null;
         $this->twig->method('render')
@@ -135,6 +138,7 @@ final class PayPalButtonsControllerTest extends TestCase
         $this->controller->renderCartPageButtonsAction(Request::create('/', 'GET', ['orderId' => 1]));
 
         self::assertFalse($capturedContext['paylaterEnabled']);
+        self::assertTrue($capturedContext['venmoEnabled']);
     }
 
     #[Test]
@@ -144,6 +148,7 @@ final class PayPalButtonsControllerTest extends TestCase
         $order->method('getCurrencyCode')->willReturn('USD');
         $this->orderRepository->method('find')->willReturn($order);
         $this->fundingSourcesConfigurationProvider->method('isPayLaterEnabled')->with($this->channel)->willReturn(true);
+        $this->fundingSourcesConfigurationProvider->method('isVenmoEnabled')->with($this->channel)->willReturn(true);
 
         $capturedContext = null;
         $this->twig->method('render')
@@ -157,6 +162,7 @@ final class PayPalButtonsControllerTest extends TestCase
         $this->controller->renderPaymentPageButtonsAction(Request::create('/', 'GET', ['orderId' => 1]));
 
         self::assertTrue($capturedContext['paylaterEnabled']);
+        self::assertTrue($capturedContext['venmoEnabled']);
     }
 
     #[Test]

--- a/tests/Unit/Controller/PayPalButtonsControllerTest.php
+++ b/tests/Unit/Controller/PayPalButtonsControllerTest.php
@@ -122,6 +122,7 @@ final class PayPalButtonsControllerTest extends TestCase
     {
         $order = $this->createMock(OrderInterface::class);
         $order->method('getCurrencyCode')->willReturn('USD');
+        $order->method('getTotal')->willReturn(3050);
         $this->orderRepository->method('find')->willReturn($order);
         $this->fundingSourcesConfigurationProvider->method('isPayLaterEnabled')->with($this->channel)->willReturn(false);
         $this->fundingSourcesConfigurationProvider->method('isVenmoEnabled')->with($this->channel)->willReturn(true);
@@ -139,6 +140,7 @@ final class PayPalButtonsControllerTest extends TestCase
 
         self::assertFalse($capturedContext['paylaterEnabled']);
         self::assertTrue($capturedContext['venmoEnabled']);
+        self::assertSame('30.50', $capturedContext['amount']);
     }
 
     #[Test]
@@ -146,6 +148,7 @@ final class PayPalButtonsControllerTest extends TestCase
     {
         $order = $this->createMock(OrderInterface::class);
         $order->method('getCurrencyCode')->willReturn('USD');
+        $order->method('getTotal')->willReturn(3000);
         $this->orderRepository->method('find')->willReturn($order);
         $this->fundingSourcesConfigurationProvider->method('isPayLaterEnabled')->with($this->channel)->willReturn(true);
         $this->fundingSourcesConfigurationProvider->method('isVenmoEnabled')->with($this->channel)->willReturn(true);
@@ -163,6 +166,7 @@ final class PayPalButtonsControllerTest extends TestCase
 
         self::assertTrue($capturedContext['paylaterEnabled']);
         self::assertTrue($capturedContext['venmoEnabled']);
+        self::assertSame('30.00', $capturedContext['amount']);
     }
 
     #[Test]

--- a/tests/Unit/Form/Type/PayPalConfigurationTypeTest.php
+++ b/tests/Unit/Form/Type/PayPalConfigurationTypeTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\PayPalPlugin\Unit\Form\Type;
+
+use PHPUnit\Framework\Attributes\Test;
+use Sylius\PayPalPlugin\Form\Type\PayPalConfigurationType;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+final class PayPalConfigurationTypeTest extends TypeTestCase
+{
+    protected function getExtensions(): array
+    {
+        return [new PreloadedExtension([new PayPalConfigurationType()], [])];
+    }
+
+    #[Test]
+    public function the_funding_source_toggles_default_to_checked_for_a_new_payment_method(): void
+    {
+        $form = $this->factory->create(PayPalConfigurationType::class, $this->baseConfig());
+
+        self::assertTrue($form->get('paylater_enabled')->getData());
+        self::assertTrue($form->get('venmo_enabled')->getData());
+        self::assertTrue($form->get('messaging_enabled')->getData());
+    }
+
+    #[Test]
+    public function an_unchecked_toggle_is_correctly_submitted_as_false(): void
+    {
+        $form = $this->factory->create(PayPalConfigurationType::class, $this->baseConfig());
+
+        // an unchecked checkbox is simply absent from the submitted payload - not a bug to
+        // special-case, this is how HTML forms work. clearMissing must stay true (the default,
+        // matching a real POST submission) for that omission to actually register as "false"
+        // rather than "unchanged".
+        $form->submit($this->submittedFields());
+
+        self::assertTrue($form->isValid());
+        self::assertFalse($form->getData()['paylater_enabled']);
+        self::assertFalse($form->getData()['venmo_enabled']);
+        self::assertFalse($form->getData()['messaging_enabled']);
+    }
+
+    #[Test]
+    public function a_checked_toggle_stays_true_after_being_resubmitted(): void
+    {
+        $form = $this->factory->create(PayPalConfigurationType::class, $this->baseConfig());
+
+        $form->submit(array_merge($this->submittedFields(), [
+            'paylater_enabled' => '1',
+            'venmo_enabled' => '1',
+            'messaging_enabled' => '1',
+        ]));
+
+        self::assertTrue($form->isValid());
+        self::assertTrue($form->getData()['paylater_enabled']);
+        self::assertTrue($form->getData()['venmo_enabled']);
+        self::assertTrue($form->getData()['messaging_enabled']);
+    }
+
+    /** @return array<string, mixed> */
+    private function baseConfig(): array
+    {
+        return [
+            'client_id' => 'CLIENT_ID', 'client_secret' => 'CLIENT_SECRET', 'merchant_id' => 'MERCHANT_ID',
+            'sylius_merchant_id' => 'MERCHANT_ID', 'partner_attribution_id' => 'bn', 'use_authorize' => 1,
+            'reports_sftp_username' => null, 'reports_sftp_password' => null,
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function submittedFields(): array
+    {
+        return [
+            'client_id' => 'CLIENT_ID', 'client_secret' => 'CLIENT_SECRET',
+            'reports_sftp_username' => '', 'reports_sftp_password' => '',
+        ];
+    }
+}

--- a/tests/Unit/Provider/PayPalConfigurationProviderTest.php
+++ b/tests/Unit/Provider/PayPalConfigurationProviderTest.php
@@ -22,6 +22,7 @@ use Sylius\Component\Core\Repository\PaymentMethodRepositoryInterface;
 use Sylius\Component\Payment\Model\GatewayConfigInterface;
 use Sylius\PayPalPlugin\Provider\PayPalConfigurationProvider;
 use Sylius\PayPalPlugin\Provider\PayPalConfigurationProviderInterface;
+use Sylius\PayPalPlugin\Provider\PayPalFundingSourcesConfigurationProviderInterface;
 
 final class PayPalConfigurationProviderTest extends TestCase
 {
@@ -41,6 +42,60 @@ final class PayPalConfigurationProviderTest extends TestCase
     public function it_implements_pay_pal_configuration_provider_interface(): void
     {
         self::assertInstanceOf(PayPalConfigurationProviderInterface::class, $this->payPalConfigurationProvider);
+    }
+
+    #[Test]
+    public function it_implements_pay_pal_funding_sources_configuration_provider_interface(): void
+    {
+        self::assertInstanceOf(PayPalFundingSourcesConfigurationProviderInterface::class, $this->payPalConfigurationProvider);
+    }
+
+    #[Test]
+    public function it_considers_paylater_enabled_by_default_when_the_config_key_is_absent(): void
+    {
+        $channel = $this->configurePayPalPaymentMethodConfig([]);
+
+        self::assertTrue($this->payPalConfigurationProvider->isPayLaterEnabled($channel));
+    }
+
+    #[Test]
+    public function it_considers_paylater_disabled_when_explicitly_set_to_false(): void
+    {
+        $channel = $this->configurePayPalPaymentMethodConfig(['paylater_enabled' => false]);
+
+        self::assertFalse($this->payPalConfigurationProvider->isPayLaterEnabled($channel));
+    }
+
+    #[Test]
+    public function it_considers_venmo_enabled_by_default_when_the_config_key_is_absent(): void
+    {
+        $channel = $this->configurePayPalPaymentMethodConfig([]);
+
+        self::assertTrue($this->payPalConfigurationProvider->isVenmoEnabled($channel));
+    }
+
+    #[Test]
+    public function it_considers_venmo_disabled_when_explicitly_set_to_false(): void
+    {
+        $channel = $this->configurePayPalPaymentMethodConfig(['venmo_enabled' => false]);
+
+        self::assertFalse($this->payPalConfigurationProvider->isVenmoEnabled($channel));
+    }
+
+    #[Test]
+    public function it_considers_messaging_enabled_by_default_when_the_config_key_is_absent(): void
+    {
+        $channel = $this->configurePayPalPaymentMethodConfig([]);
+
+        self::assertTrue($this->payPalConfigurationProvider->isMessagingEnabled($channel));
+    }
+
+    #[Test]
+    public function it_considers_messaging_disabled_when_explicitly_set_to_false(): void
+    {
+        $channel = $this->configurePayPalPaymentMethodConfig(['messaging_enabled' => false]);
+
+        self::assertFalse($this->payPalConfigurationProvider->isMessagingEnabled($channel));
     }
 
     #[Test]
@@ -243,5 +298,24 @@ final class PayPalConfigurationProviderTest extends TestCase
 
         $this->expectException(\InvalidArgumentException::class);
         $this->payPalConfigurationProvider->getPartnerAttributionId($channel);
+    }
+
+    /** @param array<string, mixed> $config */
+    private function configurePayPalPaymentMethodConfig(array $config): ChannelInterface&MockObject
+    {
+        $channel = $this->createMock(ChannelInterface::class);
+        $payPalPaymentMethod = $this->createMock(PaymentMethodInterface::class);
+        $payPalGatewayConfig = $this->createMock(GatewayConfigInterface::class);
+
+        $this->paymentMethodRepository
+            ->method('findEnabledForChannel')
+            ->with($channel)
+            ->willReturn([$payPalPaymentMethod]);
+
+        $payPalPaymentMethod->method('getGatewayConfig')->willReturn($payPalGatewayConfig);
+        $payPalGatewayConfig->method('getFactoryName')->willReturn('sylius_paypal');
+        $payPalGatewayConfig->method('getConfig')->willReturn($config);
+
+        return $channel;
     }
 }

--- a/tests/Unit/Provider/PayPalWebSdkConfigurationProviderTest.php
+++ b/tests/Unit/Provider/PayPalWebSdkConfigurationProviderTest.php
@@ -18,11 +18,14 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\PayPalPlugin\Provider\PayPalConfigurationProviderInterface;
+use Sylius\PayPalPlugin\Provider\PayPalFundingSourcesConfigurationProviderInterface;
 use Sylius\PayPalPlugin\Provider\PayPalWebSdkConfigurationProvider;
 
 final class PayPalWebSdkConfigurationProviderTest extends TestCase
 {
     private PayPalConfigurationProviderInterface&MockObject $payPalConfigurationProvider;
+
+    private PayPalFundingSourcesConfigurationProviderInterface&MockObject $fundingSourcesConfigurationProvider;
 
     private PayPalWebSdkConfigurationProvider $provider;
 
@@ -30,9 +33,11 @@ final class PayPalWebSdkConfigurationProviderTest extends TestCase
     {
         parent::setUp();
         $this->payPalConfigurationProvider = $this->createMock(PayPalConfigurationProviderInterface::class);
+        $this->fundingSourcesConfigurationProvider = $this->createMock(PayPalFundingSourcesConfigurationProviderInterface::class);
 
         $this->provider = new PayPalWebSdkConfigurationProvider(
             $this->payPalConfigurationProvider,
+            $this->fundingSourcesConfigurationProvider,
             'https://www.sandbox.paypal.com',
         );
     }
@@ -44,11 +49,12 @@ final class PayPalWebSdkConfigurationProviderTest extends TestCase
     }
 
     #[Test]
-    public function it_builds_the_instance_config_for_the_given_channel_and_page_type(): void
+    public function it_only_includes_paypal_payments_when_venmo_is_disabled(): void
     {
         $channel = $this->createMock(ChannelInterface::class);
         $this->payPalConfigurationProvider->method('getClientId')->with($channel)->willReturn('CLIENT_ID');
         $this->payPalConfigurationProvider->method('getPartnerAttributionId')->with($channel)->willReturn('Sylius_MP_PPCP');
+        $this->fundingSourcesConfigurationProvider->method('isVenmoEnabled')->with($channel)->willReturn(false);
 
         $config = $this->provider->getInstanceConfig($channel, 'checkout');
 
@@ -56,5 +62,18 @@ final class PayPalWebSdkConfigurationProviderTest extends TestCase
         self::assertSame('CLIENT_ID', $config['clientId']);
         self::assertSame('Sylius_MP_PPCP', $config['partnerAttributionId']);
         self::assertSame('checkout', $config['pageType']);
+    }
+
+    #[Test]
+    public function it_includes_venmo_payments_when_venmo_is_enabled(): void
+    {
+        $channel = $this->createMock(ChannelInterface::class);
+        $this->payPalConfigurationProvider->method('getClientId')->willReturn('CLIENT_ID');
+        $this->payPalConfigurationProvider->method('getPartnerAttributionId')->willReturn('Sylius_MP_PPCP');
+        $this->fundingSourcesConfigurationProvider->method('isVenmoEnabled')->with($channel)->willReturn(true);
+
+        $config = $this->provider->getInstanceConfig($channel, 'cart');
+
+        self::assertSame(['paypal-payments', 'venmo-payments'], $config['components']);
     }
 }

--- a/tests/Unit/Provider/PayPalWebSdkConfigurationProviderTest.php
+++ b/tests/Unit/Provider/PayPalWebSdkConfigurationProviderTest.php
@@ -39,6 +39,8 @@ final class PayPalWebSdkConfigurationProviderTest extends TestCase
             $this->payPalConfigurationProvider,
             $this->fundingSourcesConfigurationProvider,
             'https://www.sandbox.paypal.com',
+            true,
+            null,
         );
     }
 
@@ -75,5 +77,62 @@ final class PayPalWebSdkConfigurationProviderTest extends TestCase
         $config = $this->provider->getInstanceConfig($channel, 'cart');
 
         self::assertSame(['paypal-payments', 'venmo-payments'], $config['components']);
+    }
+
+    #[Test]
+    public function it_includes_the_test_buyer_country_in_sandbox_when_configured(): void
+    {
+        $channel = $this->createMock(ChannelInterface::class);
+        $this->fundingSourcesConfigurationProvider->method('isVenmoEnabled')->willReturn(false);
+
+        $provider = new PayPalWebSdkConfigurationProvider(
+            $this->payPalConfigurationProvider,
+            $this->fundingSourcesConfigurationProvider,
+            'https://www.sandbox.paypal.com',
+            true,
+            'US',
+        );
+
+        $config = $provider->getInstanceConfig($channel, 'cart');
+
+        self::assertSame('US', $config['testBuyerCountry']);
+    }
+
+    #[Test]
+    public function it_omits_the_test_buyer_country_in_sandbox_when_not_configured(): void
+    {
+        $channel = $this->createMock(ChannelInterface::class);
+        $this->fundingSourcesConfigurationProvider->method('isVenmoEnabled')->willReturn(false);
+
+        $provider = new PayPalWebSdkConfigurationProvider(
+            $this->payPalConfigurationProvider,
+            $this->fundingSourcesConfigurationProvider,
+            'https://www.sandbox.paypal.com',
+            true,
+            null,
+        );
+
+        $config = $provider->getInstanceConfig($channel, 'cart');
+
+        self::assertArrayNotHasKey('testBuyerCountry', $config);
+    }
+
+    #[Test]
+    public function it_never_includes_the_test_buyer_country_outside_sandbox_even_when_configured(): void
+    {
+        $channel = $this->createMock(ChannelInterface::class);
+        $this->fundingSourcesConfigurationProvider->method('isVenmoEnabled')->willReturn(false);
+
+        $provider = new PayPalWebSdkConfigurationProvider(
+            $this->payPalConfigurationProvider,
+            $this->fundingSourcesConfigurationProvider,
+            'https://www.paypal.com',
+            false,
+            'US',
+        );
+
+        $config = $provider->getInstanceConfig($channel, 'cart');
+
+        self::assertArrayNotHasKey('testBuyerCountry', $config);
     }
 }

--- a/tests/Unit/Twig/PayPalExtensionTest.php
+++ b/tests/Unit/Twig/PayPalExtensionTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\PayPalPlugin\Unit\Twig;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\PayPalPlugin\Provider\PayPalFundingSourcesConfigurationProviderInterface;
+use Sylius\PayPalPlugin\Twig\PayPalExtension;
+
+final class PayPalExtensionTest extends TestCase
+{
+    private PayPalFundingSourcesConfigurationProviderInterface&MockObject $fundingSourcesConfigurationProvider;
+
+    private ChannelContextInterface&MockObject $channelContext;
+
+    private PayPalExtension $extension;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->fundingSourcesConfigurationProvider = $this->createMock(PayPalFundingSourcesConfigurationProviderInterface::class);
+        $this->channelContext = $this->createMock(ChannelContextInterface::class);
+        $this->extension = new PayPalExtension(true, $this->fundingSourcesConfigurationProvider, $this->channelContext);
+    }
+
+    #[Test]
+    public function it_returns_whether_messaging_is_enabled_for_the_current_channel(): void
+    {
+        $channel = $this->createMock(ChannelInterface::class);
+        $this->channelContext->method('getChannel')->willReturn($channel);
+        $this->fundingSourcesConfigurationProvider->method('isMessagingEnabled')->with($channel)->willReturn(true);
+
+        self::assertTrue($this->extension->isMessagingEnabled());
+    }
+
+    #[Test]
+    public function it_returns_false_when_no_pay_pal_payment_method_is_configured_for_the_channel(): void
+    {
+        $channel = $this->createMock(ChannelInterface::class);
+        $this->channelContext->method('getChannel')->willReturn($channel);
+        $this->fundingSourcesConfigurationProvider
+            ->method('isMessagingEnabled')
+            ->willThrowException(new \InvalidArgumentException('No PayPal payment method defined'));
+
+        self::assertFalse($this->extension->isMessagingEnabled());
+    }
+}

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -14,8 +14,10 @@ sylius_paypal:
     invalid_form: 'Form is invalid'
     label: 'PayPal'
     merchant_id: 'Merchant ID'
+    messaging_enabled: 'Enable Pay Later messaging'
     missing_billing_address_content: 'Please, go back to the Addressing step and complete it'
     missing_billing_address_header: 'We could not fetch any billing address from PayPal'
+    paylater_enabled: 'Enable Pay Later'
     pay_with_card: 'Pay with Card'
     pay_with_paypal: 'Pay with PayPal'
     report: 'Report'
@@ -23,3 +25,4 @@ sylius_paypal:
     sftp_username: 'SFTP Username'
     share_data_consent_confirmation: "By clicking Yes, you accept PayPal share data consent"
     tender_type: 'Refunded to the PayPal wallet'
+    venmo_enabled: 'Enable Venmo'


### PR DESCRIPTION
Summary

  Adds two v6 Web SDK payment methods on top of the existing PayPal button placements (cart, product, checkout payment page), plus the admin toggles to control them:

  - Pay Later (paypal-pay-later-button): its own payment session (createPayLaterOneTimePaymentSession), gated on findEligibleMethods().isEligible('paylater'), configured with the productCode/countryCode returned by getDetails('paylater').
  - Venmo (venmo-button): its own session (createVenmoOneTimePaymentSession), gated on isEligible('venmo'), with venmo-payments requested on the SDK instance only when enabled.
  - Per-channel admin toggles on the PayPal payment method's gateway config — paylater_enabled, venmo_enabled, messaging_enabled — default on for both new and existing payment methods (missing key treated as true), editable as plain checkboxes.
  - Messaging: toggle + Twig-hook placement plumbing only (div data-paypal-messaging-placeholder). PayPal's own spec for this (SDD §6.1) is a dead link, and the shipped web-sdk/v6/core bundle only lists paypal-messages as a components enum string with no registered custom element for it — no real implementation was
    guessable from what's actually available, so this is left as scaffolding behind the toggle rather than a guessed integration.
  - No backend changes: both new sessions reuse the existing create/capture endpoints and the same createOrder/onApprove/onCancel/onError Stimulus methods the paypal session already uses — the JSON contract is payment-method-agnostic.
