### PR TITLE
Fix the express checkout button layout and its cancellation flash

### DIFF
--- a/src/Controller/CancelPayPalOrderAction.php
+++ b/src/Controller/CancelPayPalOrderAction.php
@@ -39,7 +39,7 @@ final readonly class CancelPayPalOrderAction
 
     public function __invoke(Request $request): Response
     {
-        FlashBagProvider::getFlashBag($this->flashBagOrRequestStack)->add('success', 'sylius.pay_pal.order_cancelled');
+        FlashBagProvider::getFlashBag($this->flashBagOrRequestStack)->add('success', 'sylius_paypal.order_cancelled');
 
         return new Response('', Response::HTTP_NO_CONTENT);
     }

--- a/templates/pay_from_cart_page.html.twig
+++ b/templates/pay_from_cart_page.html.twig
@@ -9,7 +9,7 @@
         errorUrl: errorPayPalPaymentUrl,
         loadingSelector: '[data-live-name-value="sylius_shop:cart:form"] [data-loading]',
     }) }}
-    style="margin-top: 10px"
+    class="d-grid gap-2"
 >
-    <paypal-button {{ stimulus_target('@sylius/paypal-plugin/paypal-web-sdk', 'paypalButton') }} type="pay" class="paypal-gold" hidden></paypal-button>
+    <paypal-button {{ stimulus_target('@sylius/paypal-plugin/paypal-web-sdk', 'paypalButton') }} type="pay" class="paypal-gold w-100" hidden></paypal-button>
 </div>

--- a/templates/shop/cart/index/content/form/sections/general/paypal_checkout.html.twig
+++ b/templates/shop/cart/index/content/form/sections/general/paypal_checkout.html.twig
@@ -1,3 +1,3 @@
-<div class="d-grid" data-live-ignore>
+<div class="mt-2" data-live-ignore>
     {{ render(controller('sylius_paypal.controller.paypal_buttons::renderCartPageButtonsAction', {'orderId': hookable_metadata.context.resource.id})) }}
 </div>

--- a/templates/shop/product/show/content/info/summary/paypal_checkout.html.twig
+++ b/templates/shop/product/show/content/info/summary/paypal_checkout.html.twig
@@ -1,3 +1,3 @@
-<div data-live-ignore>
+<div class="mb-4" data-live-ignore>
     {{ render(controller('sylius_paypal.controller.paypal_buttons::renderProductPageButtonsAction', { productId: hookable_metadata.context.product.id })) }}
 </div>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | phase-1
| Bug fix?        | no
| New feature?    | no
| Related tickets | 

Product page:
Before:
<img width="475" height="671" alt="Zrzut ekranu 2026-09-10 o 12 03 52" src="https://github.com/user-attachments/assets/09673728-0fc9-43b7-862d-073db65ccd03" />

After:
<img width="477" height="649" alt="Zrzut ekranu 2026-09-10 o 12 52 51" src="https://github.com/user-attachments/assets/9ed4cfdb-357e-4c5f-8fec-90732e14e45c" />

Cart summary:
Before:
<img width="704" height="517" alt="Zrzut ekranu 2026-09-10 o 12 04 57" src="https://github.com/user-attachments/assets/0c325053-5e23-4cfb-abef-3be40b1bcd0c" />

After:
<img width="810" height="517" alt="Zrzut ekranu 2026-09-10 o 13 04 41" src="https://github.com/user-attachments/assets/3eeabd0a-ae1a-496f-88ba-92d420cfcd1e" />
