### PR TITLE
Expose a dedicated cache pool for the plugin

### DIFF
--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -361,3 +361,31 @@
 
    This is where to hook in if you need to change what reaches PayPal — overriding `CreateOrderApi` for that
    is no longer necessary.
+
+1. #### The plugin now caches in its own pool instead of the application's `cache.app`.
+
+   Both places where the plugin caches — the PayPal callback certificates used to verify the shipping
+   callback signature, and the cooldown that rate-limits webhook id re-resolution — wrote to `cache.app`,
+   mixing the plugin's entries into your shop's own cache. They now go through `sylius_paypal.cache`,
+   a private pool parented to `cache.app` and tagged `cache.pool`.
+
+   **No action is required.** The pool inherits whatever adapter you configured in `framework.cache.app`,
+   so the plugin follows your Redis, Memcached or filesystem setup as before — it just gets its own
+   namespace inside it, and its own `bin/console cache:pool:clear sylius_paypal.cache` target.
+
+   Two consequences worth knowing:
+
+   - Existing entries are not migrated. The new namespace starts cold, which costs one extra certificate
+     download and resets the webhook id refresh cooldown once.
+   - Clearing `sylius_paypal.cache` drops both the certificates and the cooldown locks, which allows one
+     additional webhook id refresh burst. Clear it per concern only if you split the pool yourself.
+
+   To put the plugin's cache on a different backend than the rest of the application, redefine the service
+   in your own configuration:
+
+   ```yaml
+   services:
+       sylius_paypal.cache:
+           parent: cache.adapter.redis
+           tags: ['cache.pool']
+   ```

--- a/config/services/api.xml
+++ b/config/services/api.xml
@@ -20,6 +20,7 @@
         <parameter key="sylius_paypal.request_trials_limit">5</parameter>
         <parameter key="sylius_paypal.webhook_base_url"></parameter>
         <parameter key="sylius_paypal.webhook_id_refresh_cooldown">300</parameter>
+        <parameter key="sylius_paypal.callback_certificate_lifetime">86400</parameter>
     </parameters>
     <services>
         <service
@@ -138,7 +139,8 @@
         >
             <argument type="service" id="sylius.http_client" />
             <argument type="service" id="Psr\Http\Message\RequestFactoryInterface" />
-            <argument type="service" id="cache.app" />
+            <argument type="service" id="sylius_paypal.cache" />
+            <argument>%sylius_paypal.callback_certificate_lifetime%</argument>
         </service>
         <service id="Sylius\PayPalPlugin\Api\PayPalCallbackSignatureVerifierInterface" alias="sylius_paypal.api.paypal_callback_signature_verifier" />
 
@@ -160,7 +162,7 @@
         >
             <argument type="service" id=".inner" />
             <argument type="service" id="doctrine.orm.entity_manager" />
-            <argument type="service" id="cache.app" />
+            <argument type="service" id="sylius_paypal.cache" />
             <argument>%sylius_paypal.webhook_id_refresh_cooldown%</argument>
         </service>
         <service id="Sylius\PayPalPlugin\Provider\WebhookIdProviderInterface" alias="sylius_paypal.provider.webhook_id" />

--- a/config/services/cache.xml
+++ b/config/services/cache.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Sylius Sp. z o.o.
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container
+    xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd"
+>
+    <services>
+        <service id="sylius_paypal.cache" parent="cache.app" public="false">
+            <tag name="cache.pool" />
+        </service>
+    </services>
+</container>

--- a/src/Api/PayPalCallbackSignatureVerifier.php
+++ b/src/Api/PayPalCallbackSignatureVerifier.php
@@ -26,12 +26,11 @@ final readonly class PayPalCallbackSignatureVerifier implements PayPalCallbackSi
 
     private const MAX_AGE_IN_SECONDS = 300;
 
-    private const CERTIFICATE_LIFETIME_IN_SECONDS = 86400;
-
     public function __construct(
         private ClientInterface $client,
         private RequestFactoryInterface $requestFactory,
         private CacheItemPoolInterface $cache,
+        private int $certificateLifetime,
     ) {
     }
 
@@ -114,7 +113,7 @@ final readonly class PayPalCallbackSignatureVerifier implements PayPalCallbackSi
         }
 
         $item->set($certificate);
-        $item->expiresAfter(self::CERTIFICATE_LIFETIME_IN_SECONDS);
+        $item->expiresAfter($this->certificateLifetime);
         $this->cache->save($item);
 
         return $certificate;

--- a/tests/Unit/Api/PayPalCallbackSignatureVerifierTest.php
+++ b/tests/Unit/Api/PayPalCallbackSignatureVerifierTest.php
@@ -34,6 +34,8 @@ final class PayPalCallbackSignatureVerifierTest extends TestCase
 
     private const TRANSMISSION_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
 
+    private const CERTIFICATE_LIFETIME = 86400;
+
     private static \OpenSSLAsymmetricKey $privateKey;
 
     private static string $certificate;
@@ -75,7 +77,12 @@ final class PayPalCallbackSignatureVerifierTest extends TestCase
         $this->cacheItem->method('set')->willReturnSelf();
         $this->cacheItem->method('expiresAfter')->willReturnSelf();
 
-        $this->verifier = new PayPalCallbackSignatureVerifier($this->client, $this->requestFactory, $this->cache);
+        $this->verifier = new PayPalCallbackSignatureVerifier(
+            $this->client,
+            $this->requestFactory,
+            $this->cache,
+            self::CERTIFICATE_LIFETIME,
+        );
     }
 
     public function test_it_implements_paypal_callback_signature_verifier_interface(): void
@@ -172,6 +179,29 @@ final class PayPalCallbackSignatureVerifierTest extends TestCase
         $this->client->expects(self::never())->method('sendRequest');
 
         self::assertTrue($this->verifier->verify($this->signedRequest()));
+    }
+
+    public function test_it_caches_the_downloaded_certificate_for_the_configured_lifetime(): void
+    {
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cacheItem = $this->createMock(CacheItemInterface::class);
+
+        $cacheItem->method('isHit')->willReturn(false);
+        $cache->expects(self::once())->method('getItem')->with('sylius_paypal_callback_certificate_' . sha1(self::CERT_URL))->willReturn($cacheItem);
+        $cacheItem->expects(self::once())->method('set')->with(self::$certificate)->willReturnSelf();
+        $cacheItem->expects(self::once())->method('expiresAfter')->with(self::CERTIFICATE_LIFETIME)->willReturnSelf();
+        $cache->expects(self::once())->method('save')->with($cacheItem);
+
+        $this->mockCertificateDownload(self::$certificate);
+
+        $verifier = new PayPalCallbackSignatureVerifier(
+            $this->client,
+            $this->requestFactory,
+            $cache,
+            self::CERTIFICATE_LIFETIME,
+        );
+
+        self::assertTrue($verifier->verify($this->signedRequest()));
     }
 
     private function mockCertificateDownload(string $certificate): void


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | phase-1
| Bug fix?        | no
| New feature?    | yes
| Related tickets | after https://github.com/Sylius/PayPalPlugin/pull/683#discussion_r3978006917

The callback certificate verifier and the webhook id refresh cooldown both wrote to the application's `cache.app` pool, mixing plugin entries into the shop's own cache with no namespace of their own and no way to clear only the plugin's data.

Both now use `sylius_paypal.cache`, a private pool parented to `cache.app` and tagged `cache.pool`, following the pattern Symfony itself uses for `cache.scheduler`. The pool inherits whatever adapter the application configured in `framework.cache.app`, gets its own namespace, and can be cleared on its own.

The certificate lifetime moves from a class constant to `sylius_paypal.callback_certificate_lifetime`, matching how the refresh cooldown and Sylius core's own cached providers expose their TTLs.